### PR TITLE
WebSocket connections: Server, Client, Starlette adapter (Phase 3.2)

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -1,0 +1,57 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>transports — live model over WebSocket</title>
+    <style>
+      body {
+        font-family: system-ui, sans-serif;
+        margin: 3rem;
+        color: #222;
+      }
+      #tick {
+        font-size: 5rem;
+        font-variant-numeric: tabular-nums;
+      }
+      pre {
+        color: #888;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>transports — live model over WebSocket</h1>
+    <p>
+      A Python <code>Session</code> hosts a counter and increments it. This page
+      mirrors it by applying patches with the wasm core — no sync code, just the
+      model.
+    </p>
+    <div id="tick">—</div>
+    <pre id="raw"></pre>
+
+    <script type="module">
+      import init, { apply } from "/pkg/transports.js";
+      await init();
+
+      // Minimal mirror — the packaged Client (js/src/ts/client.ts) does exactly this.
+      const values = new Map();
+      const ws = new WebSocket(`ws://${location.host}/ws`);
+      ws.addEventListener("message", (e) => {
+        const m = JSON.parse(e.data);
+        if (m.t === "snapshot") {
+          values.set(m.id, m.value);
+        } else if (m.t === "patch") {
+          const cur = JSON.stringify(values.get(m.id));
+          values.set(m.id, JSON.parse(apply(cur, JSON.stringify(m.patch))));
+        }
+        render();
+      });
+
+      function render() {
+        const v = [...values.values()][0];
+        if (!v) return;
+        document.getElementById("tick").textContent = v.Map.tick.Int;
+        document.getElementById("raw").textContent = JSON.stringify(v);
+      }
+    </script>
+  </body>
+</html>

--- a/examples/server.py
+++ b/examples/server.py
@@ -1,0 +1,66 @@
+"""Live demo — a Python ``Session`` hosts a model over WebSocket; the browser mirrors it.
+
+    pip install "transports[connections]" uvicorn
+    (cd js && pnpm build)          # builds the wasm the page loads (js/dist/pkg)
+    python examples/server.py      # then open http://127.0.0.1:8000
+
+The Python side increments a counter; the browser updates live, applying patches with the wasm core.
+There is no per-frame Python round-trip and no hand-written sync code on either side — just the model
+and the incremental patches the `Session` emits.
+"""
+
+import asyncio
+from pathlib import Path
+
+from pydantic import BaseModel
+from starlette.applications import Starlette
+from starlette.responses import FileResponse
+from starlette.routing import Mount, Route, WebSocketRoute
+from starlette.staticfiles import StaticFiles
+
+import transports
+
+HERE = Path(__file__).parent
+PKG = HERE.parent / "js" / "dist" / "pkg"  # wasm-bindgen output the browser loads
+
+
+class Counter(BaseModel):
+    label: str = "ticks"
+    tick: int = 0
+
+
+session = transports.Session()
+counter = Counter()
+session.host(counter)
+server = transports.Server(session)
+
+
+async def _index(request):
+    return FileResponse(HERE / "index.html")
+
+
+async def _ticker():
+    while True:
+        await asyncio.sleep(0.5)
+        counter.tick += 1  # mutate the model; the Session emits a patch on the next flush
+
+
+async def _startup():
+    asyncio.create_task(transports.autoflush(server, 0.05))  # broadcast patches to all clients
+    asyncio.create_task(_ticker())
+
+
+app = Starlette(
+    routes=[
+        Route("/", _index),
+        WebSocketRoute("/ws", transports.starlette_endpoint(server)),
+        Mount("/pkg", app=StaticFiles(directory=str(PKG))),
+    ],
+    on_startup=[_startup],
+)
+
+
+if __name__ == "__main__":
+    import uvicorn
+
+    uvicorn.run(app, host="127.0.0.1", port=8000)

--- a/js/src/ts/client.ts
+++ b/js/src/ts/client.ts
@@ -1,0 +1,57 @@
+import { apply } from "./index";
+
+type SnapshotMsg = {
+  t: "snapshot";
+  id: number;
+  type: string;
+  rev: number;
+  value: unknown;
+};
+type PatchMsg = {
+  t: "patch";
+  id: number;
+  patch: { rev: number; ops: unknown[] };
+};
+
+/** Mirrors a remote transports `Session` from connection messages.
+ *
+ * Requires the wasm core to be initialized before applying patches.
+ */
+export class Client {
+  private values = new Map<number, unknown>();
+  private revs = new Map<number, number>();
+
+  /** Apply an inbound snapshot or patch message to the local mirror. */
+  recv(text: string): void {
+    const msg = JSON.parse(text) as SnapshotMsg | PatchMsg;
+    if (msg.t === "snapshot") {
+      this.values.set(msg.id, msg.value);
+      this.revs.set(msg.id, msg.rev);
+    } else if (msg.t === "patch") {
+      const cur = JSON.stringify(this.values.get(msg.id));
+      this.values.set(
+        msg.id,
+        JSON.parse(apply(cur, JSON.stringify(msg.patch))),
+      );
+      this.revs.set(msg.id, msg.patch.rev);
+    }
+  }
+
+  /** The current mirrored core `Value` of a model. */
+  value(id: number): unknown {
+    return this.values.get(id);
+  }
+
+  ids(): number[] {
+    return [...this.values.keys()];
+  }
+
+  /** Connect to a transports server and mirror it. Returns the `WebSocket`. */
+  connect(url: string): WebSocket {
+    const ws = new WebSocket(url);
+    ws.addEventListener("message", (e) =>
+      this.recv(String((e as MessageEvent).data)),
+    );
+    return ws;
+  }
+}

--- a/js/src/ts/index.ts
+++ b/js/src/ts/index.ts
@@ -24,3 +24,6 @@ export const Store = wasm.Store;
 // Plain JS object <-> core `Value` bridge (the JS analog of the Python bridge).
 export { toValue, fromValue } from "./bridge";
 export type { Value } from "./bridge";
+
+// WebSocket client that mirrors a remote Session.
+export { Client } from "./client";

--- a/js/tests/import.test.js
+++ b/js/tests/import.test.js
@@ -1,4 +1,11 @@
-import { placeholder, diff, apply, toValue, fromValue } from "../src/ts/index";
+import {
+  placeholder,
+  diff,
+  apply,
+  toValue,
+  fromValue,
+  Client,
+} from "../src/ts/index";
 import { initSync } from "../dist/pkg/transports";
 import fs from "fs";
 import { test, expect } from "@playwright/test";
@@ -22,4 +29,28 @@ test("diff/apply via the wasm core", async () => {
   const b = JSON.stringify(toValue({ on: true }));
   const patch = diff(a, b);
   expect(JSON.parse(apply(a, patch))).toEqual(JSON.parse(b));
+});
+
+test("Client mirrors a snapshot then a patch", async () => {
+  const c = new Client();
+  c.recv(
+    JSON.stringify({
+      t: "snapshot",
+      id: 1,
+      type: "Device",
+      rev: 0,
+      value: { Map: { on: { Bool: false } } },
+    }),
+  );
+  c.recv(
+    JSON.stringify({
+      t: "patch",
+      id: 1,
+      patch: {
+        rev: 1,
+        ops: [{ Set: { path: [{ Key: "on" }], value: { Bool: true } } }],
+      },
+    }),
+  );
+  expect(c.value(1)).toEqual({ Map: { on: { Bool: true } } });
 });

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,11 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+# WebSocket connection adapters (Starlette server, websockets client)
+connections = [
+    "starlette",
+    "websockets",
+]
 develop = [
     "build",
     "bump-my-version",
@@ -48,12 +53,15 @@ develop = [
     "hatch-js",
     "hatch-rs",
     "hatchling",
+    "httpx",
     "mdformat",
     "mdformat-tables>=1",
     "pytest",
     "pytest-cov",
     "ruff",
+    "starlette",
     "twine",
+    "websockets",
     "ty",
     "uv",
     "wheel",

--- a/transports/__init__.py
+++ b/transports/__init__.py
@@ -1,4 +1,7 @@
+from . import protocol
 from ._bridge import from_value, schema_of, schema_to_ts, to_value
+from .client import Client
+from .server import Server, autoflush, starlette_endpoint
 from .session import Session
 from .transports import Store, apply, decode, diff, encode  # compiled Rust extension (rust/python)
 
@@ -18,4 +21,10 @@ __all__ = [
     "from_value",
     "schema_of",
     "schema_to_ts",
+    # connections (WebSocket)
+    "Server",
+    "Client",
+    "starlette_endpoint",
+    "autoflush",
+    "protocol",
 ]

--- a/transports/client.py
+++ b/transports/client.py
@@ -1,0 +1,60 @@
+"""Mirror a remote `Session` from connection messages.
+
+`Client.recv(text)` applies snapshot/patch messages to a local mirror using the core `apply`, so the
+client tracks each remote model's value without hosting it. `connect(url)` runs a real WebSocket
+client loop for live use; the rest of the class is sync and transport-agnostic (testable without a
+network).
+"""
+
+import json
+from typing import Any, Dict, List, Type
+
+from . import protocol
+from ._bridge import M, from_value
+from .transports import apply as _apply, diff as _diff
+
+
+class Client:
+    def __init__(self) -> None:
+        self._values: Dict[int, Any] = {}
+        self._rev: Dict[int, int] = {}
+        self._type: Dict[int, str] = {}
+
+    def recv(self, text: str) -> None:
+        """Apply an inbound snapshot or patch message to the local mirror."""
+        msg = protocol.parse(text)
+        mid = msg["id"]
+        if msg["t"] == "snapshot":
+            self._values[mid] = msg["value"]
+            self._type[mid] = msg["type"]
+            self._rev[mid] = msg["rev"]
+        elif msg["t"] == "patch":
+            self._values[mid] = json.loads(_apply(json.dumps(self._values[mid]), json.dumps(msg["patch"])))
+            self._rev[mid] = msg["patch"]["rev"]
+
+    def value(self, mid: int) -> Any:
+        """The current mirrored core `Value` of a model."""
+        return self._values[mid]
+
+    def model(self, mid: int, cls: Type[M]) -> M:
+        """Materialize the mirrored model as an instance of `cls`."""
+        return from_value(self._values[mid], cls)
+
+    def ids(self) -> List[int]:
+        return list(self._values)
+
+    def edit(self, mid: int, new_value: Any) -> str:
+        """Locally edit a mirrored model and return the patch message to send to the server."""
+        patch = json.loads(_diff(json.dumps(self._values[mid]), json.dumps(new_value)))
+        patch["rev"] = self._rev[mid] + 1
+        self._values[mid] = new_value
+        self._rev[mid] = patch["rev"]
+        return protocol.patch_msg(mid, patch)
+
+    async def connect(self, url: str) -> None:
+        """Connect to a transports server and mirror it until the connection closes."""
+        import websockets
+
+        async with websockets.connect(url) as ws:
+            async for text in ws:
+                self.recv(text if isinstance(text, str) else text.decode())

--- a/transports/protocol.py
+++ b/transports/protocol.py
@@ -1,0 +1,26 @@
+"""The connection wire protocol: one logical frame per message, as JSON.
+
+WebSocket messages (and Jupyter comm messages) are self-delimiting, so the binary `Frame` envelope
+in the Rust core — which exists for byte-stream transports like TCP — isn't needed here. A small
+JSON envelope carries the routing metadata around a model snapshot or a patch.
+
+Two message kinds:
+
+- ``{"t": "snapshot", "id": <int>, "type": <str>, "rev": <int>, "value": <Value>}``
+- ``{"t": "patch", "id": <int>, "patch": {"rev": <int>, "ops": [...]}}``
+"""
+
+import json
+from typing import Any
+
+
+def snapshot_msg(model_id: int, type_name: str, rev: int, value: Any) -> str:
+    return json.dumps({"t": "snapshot", "id": model_id, "type": type_name, "rev": rev, "value": value})
+
+
+def patch_msg(model_id: int, patch: dict) -> str:
+    return json.dumps({"t": "patch", "id": model_id, "patch": patch})
+
+
+def parse(text: str) -> dict:
+    return json.loads(text)

--- a/transports/server.py
+++ b/transports/server.py
@@ -1,0 +1,99 @@
+"""Serve a reactive `Session` over connections (WebSocket, ...).
+
+`Server` holds the transport-agnostic logic — register connections, send snapshots on open, relay
+inbound patches, broadcast outbound patches — as plain synchronous methods that *return* the messages
+to send, keyed by connection. The actual async I/O lives in a thin adapter (`starlette_endpoint` /
+`autoflush`), so the protocol is testable without a network.
+
+A connection handle is any hashable object (the Starlette `WebSocket`, a test sentinel, ...) that the
+I/O adapter knows how to send on.
+"""
+
+import asyncio
+from typing import Any, Dict, List
+
+from . import protocol
+from .session import Session
+
+
+class Server:
+    def __init__(self, session: Session) -> None:
+        self._session = session
+        self._conns: set = set()
+
+    def open(self, conn: Any) -> List[str]:
+        """Register a connection; returns the snapshot messages to send it (current model state)."""
+        self._conns.add(conn)
+        out: List[str] = []
+        for mid in self._session.ids():
+            snap = self._session.snapshot(mid)
+            out.append(protocol.snapshot_msg(mid, snap["type_name"], snap["rev"], snap["value"]))
+        return out
+
+    def recv(self, conn: Any, text: str) -> Dict[Any, List[str]]:
+        """Handle an inbound message; returns messages to send, keyed by connection.
+
+        A client patch is applied to the hosted model's value and relayed to the *other* connections,
+        so the server acts as a hub.
+        """
+        msg = protocol.parse(text)
+        if msg.get("t") == "patch":
+            self._session.apply_patch(msg["id"], msg["patch"])
+            relay = protocol.patch_msg(msg["id"], msg["patch"])
+            return {c: [relay] for c in self._conns if c is not conn}
+        return {}
+
+    def flush(self) -> Dict[Any, List[str]]:
+        """Drain the session and return the patch messages to broadcast to every connection."""
+        msgs = [protocol.patch_msg(mid, patch) for mid, patch in self._session.drain()]
+        if not msgs or not self._conns:
+            return {}
+        return {c: list(msgs) for c in self._conns}
+
+    def close(self, conn: Any) -> None:
+        self._conns.discard(conn)
+
+
+# --- async I/O adapters --------------------------------------------------------------------------
+
+
+def starlette_endpoint(server: Server):
+    """Build a Starlette WebSocket endpoint that serves `server`.
+
+    Wire it into an app, e.g. ``WebSocketRoute("/ws", starlette_endpoint(server))``, and run
+    `autoflush(server)` as a background task to stream server-side model changes to clients.
+    """
+
+    async def endpoint(websocket: Any) -> None:
+        from starlette.websockets import WebSocketDisconnect
+
+        await websocket.accept()
+        for msg in server.open(websocket):
+            await websocket.send_text(msg)
+        try:
+            while True:
+                text = await websocket.receive_text()
+                for conn, msgs in server.recv(websocket, text).items():
+                    for msg in msgs:
+                        await conn.send_text(msg)
+        except WebSocketDisconnect:
+            pass
+        finally:
+            server.close(websocket)
+
+    return endpoint
+
+
+async def autoflush(server: Server, interval: float = 0.01) -> None:
+    """Background task: periodically flush the session and broadcast patches to all connections.
+
+    Run exactly one of these per `Server` (not per connection), so a single drain feeds every client.
+    """
+    while True:
+        await asyncio.sleep(interval)
+        for conn, msgs in server.flush().items():
+            for msg in msgs:
+                try:
+                    await conn.send_text(msg)
+                except Exception:
+                    server.close(conn)

--- a/transports/session.py
+++ b/transports/session.py
@@ -40,6 +40,10 @@ class Session:
         self._models[mid] = watch(model, _watcher, deepstate=True)
         return mid
 
+    def ids(self) -> List[int]:
+        """The ids of all hosted models."""
+        return list(self._models.keys())
+
     def on_patch(self, fn: Callable[[int, dict], None]) -> None:
         """Register a callback invoked as `fn(model_id, patch)` for each emitted patch."""
         self._on_patch = fn

--- a/transports/tests/test_connection.py
+++ b/transports/tests/test_connection.py
@@ -1,0 +1,111 @@
+import json
+
+from pydantic import BaseModel
+
+from transports import Client, Server, Session, protocol, starlette_endpoint, to_value
+
+
+class Device(BaseModel):
+    name: str
+    on: bool = False
+
+
+# --- transport-agnostic logic (no network) -------------------------------------------------------
+
+
+def test_snapshot_then_patch_mirrors_server():
+    session = Session()
+    server = Server(session)
+    client = Client()
+    d = Device(name="lamp")
+    mid = session.host(d)
+
+    for m in server.open("c1"):  # connect: snapshots flow to the client
+        client.recv(m)
+    assert client.value(mid) == json.loads(json.dumps(to_value(d)))
+    assert client.model(mid, Device) == d
+
+    d.on = True  # server-side mutation -> flush -> client mirrors
+    for m in server.flush()["c1"]:
+        client.recv(m)
+    assert client.model(mid, Device).on is True
+
+
+def test_flush_broadcasts_to_every_connection():
+    session = Session()
+    server = Server(session)
+    a, b = Client(), Client()
+    d = Device(name="lamp")
+    mid = session.host(d)
+    for m in server.open("a"):
+        a.recv(m)
+    for m in server.open("b"):
+        b.recv(m)
+
+    d.name = "desk"
+    out = server.flush()
+    for m in out["a"]:
+        a.recv(m)
+    for m in out["b"]:
+        b.recv(m)
+    assert a.model(mid, Device).name == "desk"
+    assert b.model(mid, Device).name == "desk"
+
+
+def test_client_edit_relays_to_other_clients():
+    session = Session()
+    server = Server(session)
+    a, b = Client(), Client()
+    d = Device(name="lamp")
+    mid = session.host(d)
+    for m in server.open("a"):
+        a.recv(m)
+    for m in server.open("b"):
+        b.recv(m)
+
+    msg = a.edit(mid, to_value(Device(name="lamp", on=True)))  # client a edits, sends to server
+    out = server.recv("a", msg)
+    assert set(out) == {"b"}  # relayed to b, not back to a
+    for m in out["b"]:
+        b.recv(m)
+    assert b.model(mid, Device).on is True
+
+
+def test_flush_without_connections_is_empty():
+    session = Session()
+    server = Server(session)
+    d = Device(name="lamp")
+    session.host(d)
+    d.on = True
+    assert server.flush() == {}
+
+
+# --- real Starlette WebSocket I/O ----------------------------------------------------------------
+
+
+def test_starlette_connect_snapshot_and_relay():
+    from starlette.applications import Starlette
+    from starlette.routing import WebSocketRoute
+    from starlette.testclient import TestClient
+
+    session = Session()
+    server = Server(session)
+    d = Device(name="lamp")
+    mid = session.host(d)
+    app = Starlette(routes=[WebSocketRoute("/ws", starlette_endpoint(server))])
+
+    with TestClient(app) as tc, tc.websocket_connect("/ws") as ws1, tc.websocket_connect("/ws") as ws2:
+        snap1 = json.loads(ws1.receive_text())
+        snap2 = json.loads(ws2.receive_text())
+        assert snap1["t"] == "snapshot" and snap1["id"] == mid and snap1["value"] == json.loads(json.dumps(to_value(d)))
+        assert snap2["id"] == mid
+
+        # ws1 -> server -> relayed to ws2
+        ws1.send_text(protocol.patch_msg(mid, {"rev": 1, "ops": [{"Set": {"path": [{"Key": "on"}], "value": {"Bool": True}}}]}))
+        relayed = json.loads(ws2.receive_text())
+        assert relayed["t"] == "patch" and relayed["id"] == mid
+
+        client = Client()
+        client.recv(json.dumps(snap2))
+        client.recv(json.dumps(relayed))
+        assert client.model(mid, Device).on is True


### PR DESCRIPTION
Phase 3.2 — sync typed models across a real WebSocket.

A transport-agnostic, synchronous connection layer plus thin async I/O, so the protocol is testable without a network:

- **protocol.py** — JSON snapshot/patch messages (WS messages are self-delimiting, so the binary `Frame` is reserved for byte-stream transports).
- **server.py** — `Server` (`open`/`recv`/`flush`/`close` return the messages to send, keyed by connection; acts as a hub relay) + `starlette_endpoint` + `autoflush` async adapters.
- **client.py** — `Client` mirror (`recv`/`value`/`model`/`edit`) + async `connect()` (the `websockets` lib).
- **js/src/ts/client.ts** — browser/node `Client` that applies patches via the wasm core.
- `Session.ids()`; optional `transports[connections]` extra (`starlette`, `websockets`).

**Tests:** deterministic loopback, two-client broadcast, client-edit relay, and a real Starlette `TestClient` two-client relay over actual WebSocket I/O. JS: a Playwright test that mirrors a snapshot + patch via the wasm core (passes in chromium). 25 Python tests + 4 Playwright tests green; ruff/ty/prettier clean.