### PR TITLE
MessagePack codec (Phase 2.2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "autocfg"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
+
+[[package]]
 name = "bumpalo"
 version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -46,6 +52,15 @@ name = "memchr"
 version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "once_cell"
@@ -136,6 +151,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "rmp"
+version = "0.8.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ba8be72d372b2c9b35542551678538b562e7cf86c3315773cae48dfbfe7790c"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "rmp-serde"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f81bee8c8ef9b577d1681a70ebbc962c232461e397b22c208c43c04b67a155"
+dependencies = [
+ "rmp",
+ "serde",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -205,6 +239,7 @@ checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 name = "transports"
 version = "0.1.0"
 dependencies = [
+ "rmp-serde",
  "serde",
  "serde_json",
 ]

--- a/js/src/rust/lib.rs
+++ b/js/src/rust/lib.rs
@@ -27,6 +27,18 @@ pub fn decode(data: &[u8]) -> Result<String, JsError> {
     transports::decode_json(data).map_err(|e| JsError::new(&e))
 }
 
+/// Encode a JSON-encoded model with the codec named by `codec` (e.g. `"application/msgpack"`).
+#[wasm_bindgen]
+pub fn encode_as(value: &str, codec: &str) -> Result<Vec<u8>, JsError> {
+    transports::encode_as(value, codec).map_err(|e| JsError::new(&e))
+}
+
+/// Decode bytes (produced by `codec`'s codec) back to a JSON-encoded model string.
+#[wasm_bindgen]
+pub fn decode_as(data: &[u8], codec: &str) -> Result<String, JsError> {
+    transports::decode_as(data, codec).map_err(|e| JsError::new(&e))
+}
+
 /// In-process model store: host / mutate → patch / apply / snapshot.
 #[wasm_bindgen]
 pub struct Store {

--- a/js/src/ts/index.ts
+++ b/js/src/ts/index.ts
@@ -18,6 +18,14 @@ export const encode = (model: string): Uint8Array => wasm.encode(model);
 /** Decode codec bytes back to a JSON-encoded model string. */
 export const decode = (bytes: Uint8Array): string => wasm.decode(bytes);
 
+/** Encode a JSON-encoded model with the codec named by `codec` (e.g. "application/msgpack"). */
+export const encodeAs = (model: string, codec: string): Uint8Array =>
+  wasm.encode_as(model, codec);
+
+/** Decode bytes (from `codec`'s codec) back to a JSON-encoded model string. */
+export const decodeAs = (bytes: Uint8Array, codec: string): string =>
+  wasm.decode_as(bytes, codec);
+
 /** In-process model store: host / mutate → patch / apply / snapshot. */
 export const Store = wasm.Store;
 

--- a/js/tests/import.test.js
+++ b/js/tests/import.test.js
@@ -1,4 +1,12 @@
-import { placeholder, diff, apply, toValue, fromValue } from "../src/ts/index";
+import {
+  placeholder,
+  diff,
+  apply,
+  toValue,
+  fromValue,
+  encodeAs,
+  decodeAs,
+} from "../src/ts/index";
 import { initSync } from "../dist/pkg/transports";
 import fs from "fs";
 import { test, expect } from "@playwright/test";
@@ -22,4 +30,13 @@ test("diff/apply via the wasm core", async () => {
   const b = JSON.stringify(toValue({ on: true }));
   const patch = diff(a, b);
   expect(JSON.parse(apply(a, patch))).toEqual(JSON.parse(b));
+});
+
+test("msgpack round-trips via encodeAs/decodeAs", async () => {
+  const v = JSON.stringify(toValue({ name: "lamp", on: true, count: 123456 }));
+  const mp = encodeAs(v, "application/msgpack");
+  expect(mp instanceof Uint8Array).toBe(true);
+  expect(JSON.parse(decodeAs(mp, "application/msgpack"))).toEqual(
+    JSON.parse(v),
+  );
 });

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -16,3 +16,4 @@ crate-type = ["rlib"]
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+rmp-serde = "1"

--- a/rust/python/api/mod.rs
+++ b/rust/python/api/mod.rs
@@ -30,6 +30,19 @@ pub fn decode(data: &[u8]) -> PyResult<String> {
     transports::decode_json(data).map_err(PyValueError::new_err)
 }
 
+/// Encode a JSON-encoded model with the codec named by `codec` (e.g. `"application/msgpack"`).
+#[pyfunction]
+pub fn encode_as<'py>(py: Python<'py>, value: &str, codec: &str) -> PyResult<Bound<'py, PyBytes>> {
+    let bytes = transports::encode_as(value, codec).map_err(PyValueError::new_err)?;
+    Ok(PyBytes::new(py, &bytes))
+}
+
+/// Decode bytes (produced by `codec`'s codec) back to a JSON-encoded model string.
+#[pyfunction]
+pub fn decode_as(data: &[u8], codec: &str) -> PyResult<String> {
+    transports::decode_as(data, codec).map_err(PyValueError::new_err)
+}
+
 /// In-process model store: host / mutate → patch / apply / snapshot.
 #[pyclass]
 pub struct Store {

--- a/rust/python/lib.rs
+++ b/rust/python/lib.rs
@@ -9,6 +9,8 @@ fn transports(_py: Python, m: &Bound<PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(api::apply, m)?)?;
     m.add_function(wrap_pyfunction!(api::encode, m)?)?;
     m.add_function(wrap_pyfunction!(api::decode, m)?)?;
+    m.add_function(wrap_pyfunction!(api::encode_as, m)?)?;
+    m.add_function(wrap_pyfunction!(api::decode_as, m)?)?;
     m.add_class::<api::Store>()?;
     Ok(())
 }

--- a/rust/src/bridge.rs
+++ b/rust/src/bridge.rs
@@ -5,7 +5,7 @@
 //! This is the concrete "one core, two bindings": a patch produced by [`diff_json`] in Python is
 //! consumed by [`apply_json`] in the browser using the same Rust.
 
-use crate::codec::{Codec, JsonCodec};
+use crate::codec::{codec_for, Codec, JsonCodec};
 use crate::diff::{apply, diff, Patch};
 use crate::store::Store;
 use crate::value::{ModelId, Value};
@@ -34,6 +34,21 @@ pub fn encode_json(value: &str) -> Result<Vec<u8>, String> {
 /// Decode codec bytes back to a JSON-encoded model string.
 pub fn decode_json(bytes: &[u8]) -> Result<String, String> {
     let value = JsonCodec.decode_value(bytes).map_err(|e| e.to_string())?;
+    serde_json::to_string(&value).map_err(|e| e.to_string())
+}
+
+/// Encode a JSON-encoded model to bytes using the codec named by `content_type`
+/// (`"application/json"`, `"application/msgpack"`, ...).
+pub fn encode_as(value: &str, content_type: &str) -> Result<Vec<u8>, String> {
+    let value: Value = serde_json::from_str(value).map_err(|e| e.to_string())?;
+    let codec = codec_for(content_type).ok_or_else(|| format!("unknown codec: {content_type}"))?;
+    Ok(codec.encode_value(&value))
+}
+
+/// Decode codec bytes (produced by `content_type`'s codec) back to a JSON-encoded model string.
+pub fn decode_as(bytes: &[u8], content_type: &str) -> Result<String, String> {
+    let codec = codec_for(content_type).ok_or_else(|| format!("unknown codec: {content_type}"))?;
+    let value = codec.decode_value(bytes).map_err(|e| e.to_string())?;
     serde_json::to_string(&value).map_err(|e| e.to_string())
 }
 

--- a/rust/src/codec.rs
+++ b/rust/src/codec.rs
@@ -53,6 +53,42 @@ impl Codec for JsonCodec {
     }
 }
 
+/// MessagePack via `rmp-serde`. Compact binary, and self-describing — like JSON it needs no schema,
+/// so it works with the dynamic [`Value`] as a drop-in for `JsonCodec`.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct MsgpackCodec;
+
+impl Codec for MsgpackCodec {
+    fn encode_value(&self, value: &Value) -> Vec<u8> {
+        rmp_serde::to_vec(value).expect("Value serializes")
+    }
+
+    fn decode_value(&self, bytes: &[u8]) -> Result<Value, CodecError> {
+        rmp_serde::from_slice(bytes).map_err(|e| CodecError(e.to_string()))
+    }
+
+    fn encode_patch(&self, patch: &Patch) -> Vec<u8> {
+        rmp_serde::to_vec(patch).expect("Patch serializes")
+    }
+
+    fn decode_patch(&self, bytes: &[u8]) -> Result<Patch, CodecError> {
+        rmp_serde::from_slice(bytes).map_err(|e| CodecError(e.to_string()))
+    }
+
+    fn content_type(&self) -> &'static str {
+        "application/msgpack"
+    }
+}
+
+/// Look up a codec by its content-type tag — the seam codec negotiation (Phase 2.1) builds on.
+pub fn codec_for(content_type: &str) -> Option<Box<dyn Codec>> {
+    match content_type {
+        "application/json" => Some(Box::new(JsonCodec)),
+        "application/msgpack" | "application/x-msgpack" => Some(Box::new(MsgpackCodec)),
+        _ => None,
+    }
+}
+
 /*********************************/
 #[cfg(test)]
 mod codec_tests {
@@ -65,6 +101,45 @@ mod codec_tests {
         let bytes = c.encode_value(&v);
         assert_eq!(c.decode_value(&bytes).unwrap(), v);
         assert_eq!(c.content_type(), "application/json");
+    }
+
+    #[test]
+    fn test_msgpack_round_trip_and_smaller() {
+        let c = MsgpackCodec;
+        let v = Value::map([
+            ("name", Value::from("lamp")),
+            ("on", Value::from(true)),
+            ("count", Value::from(123456i64)),
+        ]);
+        let mp = c.encode_value(&v);
+        assert_eq!(c.decode_value(&mp).unwrap(), v);
+        assert_eq!(c.content_type(), "application/msgpack");
+        // self-describing binary, but more compact than JSON
+        assert!(mp.len() < JsonCodec.encode_value(&v).len());
+    }
+
+    #[test]
+    fn test_msgpack_patch_round_trip() {
+        let c = MsgpackCodec;
+        let p = crate::diff(
+            &Value::map([("on", Value::from(false))]),
+            &Value::map([("on", Value::from(true))]),
+        );
+        assert_eq!(c.decode_patch(&c.encode_patch(&p)).unwrap(), p);
+    }
+
+    #[test]
+    fn test_codec_for() {
+        assert_eq!(
+            codec_for("application/json").unwrap().content_type(),
+            "application/json"
+        );
+        assert_eq!(
+            codec_for("application/msgpack").unwrap().content_type(),
+            "application/msgpack"
+        );
+        assert!(codec_for("application/x-msgpack").is_some());
+        assert!(codec_for("application/protobuf").is_none());
     }
 
     #[test]

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -8,7 +8,7 @@
 //! - [`value`] — the typed [`Value`] a model is made of, with [`ModelId`] submodel references.
 //! - [`schema`] — [`Schema`]/[`Registry`]: type-name → schema (ports the prototype's `model_map`).
 //! - [`diff`] — structural diff/patch with `rev` sequencing (the missing `onUpdate`).
-//! - [`codec`] — the pluggable [`Codec`] trait + [`JsonCodec`].
+//! - [`codec`] — the pluggable [`Codec`] trait + [`JsonCodec`]/[`MsgpackCodec`].
 //! - [`frame`] — the length-prefixed, codec-tagged [`Frame`] envelope.
 //! - [`store`] — a minimal [`Store`]: host / mutate → patch / apply / snapshot.
 //! - [`bridge`] — the JSON string facade the bindings call.
@@ -21,8 +21,10 @@ mod schema;
 mod store;
 mod value;
 
-pub use bridge::{apply_json, decode_json, diff_json, encode_json, JsonStore};
-pub use codec::{Codec, CodecError, JsonCodec};
+pub use bridge::{
+    apply_json, decode_as, decode_json, diff_json, encode_as, encode_json, JsonStore,
+};
+pub use codec::{codec_for, Codec, CodecError, JsonCodec, MsgpackCodec};
 pub use diff::{apply, diff, Op, Patch, Path, PathSeg};
 pub use frame::{Frame, FrameError, FrameKind};
 pub use schema::{Field, FieldType, Registry, Schema};

--- a/transports/__init__.py
+++ b/transports/__init__.py
@@ -1,6 +1,6 @@
 from ._bridge import from_value, schema_of, schema_to_ts, to_value
 from .session import Session
-from .transports import Store, apply, decode, diff, encode  # compiled Rust extension (rust/python)
+from .transports import Store, apply, decode, decode_as, diff, encode, encode_as  # compiled Rust extension (rust/python)
 
 __version__ = "0.1.2"
 
@@ -10,8 +10,10 @@ __all__ = [
     "Store",
     "apply",
     "decode",
+    "decode_as",
     "diff",
     "encode",
+    "encode_as",
     # model bridge + reactive session (high-level)
     "Session",
     "to_value",

--- a/transports/tests/test_codec.py
+++ b/transports/tests/test_codec.py
@@ -1,0 +1,26 @@
+import json
+
+import pytest
+
+from transports import decode_as, encode, encode_as
+
+MODEL = json.dumps({"Map": {"name": {"Str": "lamp"}, "on": {"Bool": True}, "count": {"Int": 123456}}})
+
+
+def test_msgpack_round_trip():
+    blob = encode_as(MODEL, "application/msgpack")
+    assert isinstance(blob, bytes)
+    assert json.loads(decode_as(blob, "application/msgpack")) == json.loads(MODEL)
+
+
+def test_msgpack_is_smaller_than_json():
+    assert len(encode_as(MODEL, "application/msgpack")) < len(encode(MODEL))
+
+
+def test_json_via_encode_as_matches_encode():
+    assert encode_as(MODEL, "application/json") == encode(MODEL)
+
+
+def test_unknown_codec_raises():
+    with pytest.raises(ValueError):
+        encode_as(MODEL, "application/protobuf")

--- a/transports/transports.pyi
+++ b/transports/transports.pyi
@@ -12,6 +12,12 @@ def encode(value: str) -> bytes:
 def decode(data: bytes) -> str:
     """Decode codec bytes back to a JSON-encoded model string."""
 
+def encode_as(value: str, codec: str) -> bytes:
+    """Encode a JSON-encoded model with the codec named by `codec` (e.g. "application/msgpack")."""
+
+def decode_as(data: bytes, codec: str) -> str:
+    """Decode bytes (from `codec`'s codec) back to a JSON-encoded model string."""
+
 class Store:
     """In-process model store: host / mutate -> patch / apply / snapshot."""
 


### PR DESCRIPTION
Phase 2.2 — a binary wire behind the pluggable `Codec` trait.

- **core**: `MsgpackCodec` (`rmp-serde`) for values and patches; `codec_for(content_type)` registry (`application/json` | `application/msgpack`). Self-describing, so it works with the dynamic `Value` with no schema — a drop-in for JSON, and more compact.
- **bridge**: `encode_as(value, content_type)` / `decode_as(bytes, content_type)`.
- **bindings**: Python `transports.encode_as/decode_as`; JS `encodeAs/decodeAs`.

**Verified:** Rust tests (round-trip, smaller-than-JSON, `codec_for`); Python tests; a Playwright browser test (msgpack round-trip via wasm); and a **cross-binding byte-identity** check — Python and Node produce identical MessagePack bytes. Non-breaking: existing `encode`/`decode` (JSON) unchanged.