### PR TITLE
Docs: connections + codecs, product-focused

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ Move typed models across any wire.
 
 Define a model once — as a [pydantic](https://docs.pydantic.dev) model, a stdlib `dataclass`, or a
 [msgspec](https://jcristharif.com/msgspec/) struct — host it, and its mutations stream to peers as
-**incremental patches** (not whole-model resends). A Rust core (model representation, diff/patch,
-codecs, framing) compiles to Python (PyO3) and JavaScript (wasm), so both ends share one
-implementation byte-for-byte.
+**incremental patches** (not whole-model resends), over a WebSocket, in JSON or MessagePack. A Rust
+core (model representation, diff/patch, codecs, framing) compiles to Python (PyO3) and JavaScript
+(wasm), so both ends share one implementation.
 
 [![License](https://img.shields.io/github/license/1kbgz/transports)](https://github.com/1kbgz/transports)
 [![PyPI](https://img.shields.io/pypi/v/transports.svg)](https://pypi.python.org/pypi/transports)
@@ -33,17 +33,22 @@ for model_id, patch in session.drain():
 
 ```bash
 pip install transports
+pip install "transports[connections]"   # adds the WebSocket server/client adapters
 ```
 
 ## What you get
 
 - **Reactive models** — mutate a field, get the minimal patch. No manual diffing or `send()`.
 - **Three model kinds, one contract** — pydantic, dataclass, and msgspec all bridge to the same core.
-- **One core, two languages** — Python and JavaScript share the Rust diff/patch and codec, so a patch
-  produced on one side applies on the other.
+- **One core, two languages** — Python and JavaScript share the Rust diff/patch and codecs, so a
+  patch produced on one side applies on the other.
+- **Live sync over WebSocket** — host a model on a server and mirror it in the browser; mutate it in
+  Python and the page updates. See [Connections](docs/src/connections.md).
+- **JSON or MessagePack** — swap the wire format without touching your models. See
+  [Codecs](docs/src/codecs.md).
 
-## Status
+## Documentation
 
-Early. The Rust core (model, diff/patch with revisions, JSON codec, frame envelope, in-process store)
-and the model bridges are in. Binary codecs (MessagePack, …) and network connections (WebSocket, SSE,
-…) are on the [roadmap](https://github.com/1kbgz/transports/blob/main/ROADMAP.md).
+[Quickstart](docs/src/quickstart.md) · [Concepts](docs/src/concepts.md) ·
+[Model bridges](docs/src/bridges.md) · [Connections](docs/src/connections.md) ·
+[Codecs](docs/src/codecs.md) · [API reference](docs/src/api.md)

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -1,7 +1,6 @@
 # API Reference
 
-The high-level reactive session and model bridge, plus the low-level core (the compiled Rust
-extension).
+The high-level reactive session, the model bridge, the connection adapters, and the low-level core.
 
 ## Session
 
@@ -24,6 +23,24 @@ extension).
 .. autofunction:: transports.schema_to_ts
 ```
 
+## Connections
+
+```{eval-rst}
+.. autoclass:: transports.Server
+   :members:
+   :undoc-members:
+   :member-order: bysource
+
+.. autoclass:: transports.Client
+   :members:
+   :undoc-members:
+   :member-order: bysource
+
+.. autofunction:: transports.starlette_endpoint
+
+.. autofunction:: transports.autoflush
+```
+
 ## Core
 
 The low-level surface, exposed directly from the Rust core. Most users work through
@@ -38,6 +55,10 @@ hosting.
 .. autofunction:: transports.encode
 
 .. autofunction:: transports.decode
+
+.. autofunction:: transports.encode_as
+
+.. autofunction:: transports.decode_as
 
 .. autoclass:: transports.Store
    :members:

--- a/docs/src/bridges.md
+++ b/docs/src/bridges.md
@@ -107,9 +107,8 @@ bridged in Python are interchangeable on the wire.
 > [!NOTE]
 > JavaScript has a single number type, so integers and whole-valued floats both encode as `Int`.
 
-## Limitations (current)
+## Notes
 
-- Nested models are inlined as `Map`s; referencing a submodel by id (the `Submodel` variant) is a
-  later refinement.
-- The receive side (`apply_patch`) updates the core value; read it back with
-  `from_value(session.value(id))`. A live, in-place-updating mirrored model is not yet provided.
+- Nested models are inlined as `Map`s in the wire form.
+- On the receive side, `apply_patch` updates the mirrored core value; read it back with
+  `from_value(session.value(id))`.

--- a/docs/src/codecs.md
+++ b/docs/src/codecs.md
@@ -1,0 +1,32 @@
+# Codecs
+
+The wire format is pluggable. A **codec** turns a `Value` (or a patch) into bytes and back.
+transports ships two, both self-describing — they need no schema, and produce identical bytes from
+Python and JavaScript:
+
+| Codec | Content type | |
+|---|---|---|
+| JSON | `application/json` | human-readable; the default |
+| MessagePack | `application/msgpack` | compact binary |
+
+## Encoding
+
+`encode_as` / `decode_as` take a content type. They operate on the core `Value` in its JSON text
+form (what {py:func}`~transports.to_value` produces, serialized):
+
+```python
+import json
+import transports
+
+value = transports.to_value(Device(name="lamp", on=True))     # a Value (dict)
+blob = transports.encode_as(json.dumps(value), "application/msgpack")   # compact bytes
+restored = json.loads(transports.decode_as(blob, "application/msgpack"))
+assert restored == value
+```
+
+`transports.encode(value)` / `transports.decode(bytes)` are JSON shortcuts. In JavaScript the same
+pair is `encodeAs(value, codec)` / `decodeAs(bytes, codec)`.
+
+Because a codec only changes the *bytes* — never the model, the `Value`, or the patch semantics —
+switching formats is a one-line change and never touches your models. MessagePack is typically the
+choice for production traffic; JSON is convenient for debugging.

--- a/docs/src/concepts.md
+++ b/docs/src/concepts.md
@@ -5,8 +5,8 @@
 transports is a **Rust core** with thin **Python (PyO3)** and **JavaScript (wasm)** bindings. The
 core owns the model representation, the diff/patch engine, the codecs, and the wire framing; both
 languages call into the same compiled implementation. A patch produced by Python and a patch produced
-by JavaScript for the same change are byte-identical, so either side can host a model and the other
-can mirror it.
+by JavaScript for the same change are byte-for-byte identical, so either side can host a model and the
+other can mirror it.
 
 ```text
    Python (PyO3)            JavaScript (wasm)
@@ -51,16 +51,15 @@ and lists diff positionally; a type change at a path replaces the value there wh
 The low-level {py:class}`~transports.Store` holds model values by id and, on `mutate`, diffs the new
 value against the held one, bumps the `rev`, and returns the patch. The high-level
 {py:class}`~transports.Session` wraps it with the model bridge and reactive observation, so you work
-with your own model objects and get patches automatically.
+with your own model objects and get patches automatically — see [Model bridges](bridges.md).
 
-This is the single-owner nucleus; multi-tenant sessions (fan-out to many subscribers, backpressure,
-authorization) are on the roadmap.
+## Codecs
 
-## What's next
+The wire format is pluggable. JSON is the default; **MessagePack** is a compact binary alternative.
+Both are self-describing — they need no schema — and produce identical bytes from Python and
+JavaScript. See [Codecs](codecs.md).
 
-- **Codecs.** JSON is the current wire format, behind a pluggable codec trait. MessagePack and other
-  binary codecs are planned; they change only the *bytes*, not the model or patch semantics.
-- **Connections.** A length-prefixed, codec-tagged `Frame` envelope exists in the core; the actual
-  transport adapters (WebSocket, SSE, HTTP, Jupyter comm, TCP) come next, carrying frames between
-  processes.
-```
+## Connections
+
+Patches travel between processes over a **WebSocket**: a server hosts a `Session` and a client — in
+Python or the browser — mirrors the model live. See [Connections](connections.md).

--- a/docs/src/connections.md
+++ b/docs/src/connections.md
@@ -1,0 +1,90 @@
+# Connections
+
+Patches travel between processes over a **WebSocket**. A server hosts a
+{py:class}`~transports.Session` and broadcasts its patches; a client — in Python or the browser —
+mirrors the model live.
+
+```bash
+pip install "transports[connections]"
+```
+
+## Server
+
+A {py:class}`~transports.Server` wraps a `Session`. Its logic is transport-agnostic — it returns the
+messages to send — and {py:func}`~transports.starlette_endpoint` adapts it to a Starlette WebSocket
+route. Run {py:func}`~transports.autoflush` as a background task to stream server-side changes to
+connected clients.
+
+```python
+import asyncio
+
+import transports
+from pydantic import BaseModel
+from starlette.applications import Starlette
+from starlette.routing import WebSocketRoute
+
+class Counter(BaseModel):
+    tick: int = 0
+
+session = transports.Session()
+counter = Counter()
+session.host(counter)
+server = transports.Server(session)
+
+async def ticker():
+    while True:
+        await asyncio.sleep(1)
+        counter.tick += 1               # mutate the model; clients receive the patch
+
+async def startup():
+    asyncio.create_task(transports.autoflush(server))
+    asyncio.create_task(ticker())
+
+app = Starlette(
+    routes=[WebSocketRoute("/ws", transports.starlette_endpoint(server))],
+    on_startup=[startup],
+)
+```
+
+On connect, a client receives a snapshot of every hosted model, then a stream of patches. A patch a
+client sends back is applied and relayed to the *other* clients, so the server acts as a hub.
+
+## Python client
+
+{py:class}`~transports.Client` mirrors a remote session without hosting it:
+
+```python
+client = transports.Client()
+await client.connect("ws://localhost:8000/ws")   # mirrors until the connection closes
+client.model(mid, Counter)                       # materialize the mirrored model as a Counter
+```
+
+`Client` is also usable without a live connection — feed it messages with `recv(text)` and read with
+`value(id)` / `model(id, cls)`.
+
+## Browser client
+
+The JavaScript `Client` applies patches with the wasm core (initialize the wasm first):
+
+```ts
+import init, { Client } from "transports";
+await init();
+
+const client = new Client();
+const ws = new WebSocket("ws://localhost:8000/ws");
+ws.addEventListener("message", (e) => {
+  client.recv(e.data);
+  render(client.value(1)); // your render function
+});
+```
+
+## Runnable example
+
+A complete example — a Python server hosting a counter and a browser page that displays it updating
+live — is in [`examples/`](https://github.com/1kbgz/transports/tree/main/examples):
+
+```bash
+pip install "transports[connections]" uvicorn
+(cd js && pnpm build)        # build the wasm the page loads
+python examples/server.py    # open http://127.0.0.1:8000
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -225,6 +225,8 @@ pages = [
     "docs/src/quickstart.md",
     "docs/src/concepts.md",
     "docs/src/bridges.md",
+    "docs/src/connections.md",
+    "docs/src/codecs.md",
     "docs/src/api.md",
 ]
 exclude_patterns = [

--- a/transports/client.py
+++ b/transports/client.py
@@ -15,6 +15,11 @@ from .transports import apply as _apply, diff as _diff
 
 
 class Client:
+    """Mirrors a remote `Session` — applies snapshot/patch messages to a local copy of each model.
+
+    Read values with `value(id)` or materialize them with `model(id, cls)`. Drive it with a live
+    connection via `connect(url)`, or feed it messages directly with `recv(text)`."""
+
     def __init__(self) -> None:
         self._values: Dict[int, Any] = {}
         self._rev: Dict[int, int] = {}

--- a/transports/server.py
+++ b/transports/server.py
@@ -17,6 +17,10 @@ from .session import Session
 
 
 class Server:
+    """Serves a `Session` to connected clients: sends a snapshot on connect, broadcasts patches, and
+    relays a client's patches to the other clients (a hub). Transport-agnostic — its methods return
+    the messages to send; an adapter such as `starlette_endpoint` performs the I/O."""
+
     def __init__(self, session: Session) -> None:
         self._session = session
         self._conns: set = set()


### PR DESCRIPTION
Bring the documentation up to date with the current feature set and present it as product docs (no internal/roadmap language).

- **New pages**: Connections (WebSocket `Server`/`Client` + the runnable `examples/`) and Codecs (JSON / MessagePack via `encode_as`/`decode_as`).
- **API reference**: adds `Server`, `Client`, `starlette_endpoint`, `autoflush`, `encode_as`, `decode_as`.
- **Concepts / README**: updated to reflect that codecs and connections are available; dropped roadmap/planned/"what's next" framing.
- Added `Server`/`Client` class docstrings.

Docs build clean with `yardang build` (remaining warnings are yardang-template defaults, not content).