### PR TITLE
Negotiate the codec over a connection (2.1)

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -60,6 +60,10 @@ hosting.
 
 .. autofunction:: transports.decode_as
 
+.. autofunction:: transports.json_to_msgpack
+
+.. autofunction:: transports.msgpack_to_json
+
 .. autoclass:: transports.Store
    :members:
    :undoc-members:

--- a/docs/src/codecs.md
+++ b/docs/src/codecs.md
@@ -30,3 +30,24 @@ pair is `encodeAs(value, codec)` / `decodeAs(bytes, codec)`.
 Because a codec only changes the *bytes* — never the model, the `Value`, or the patch semantics —
 switching formats is a one-line change and never touches your models. MessagePack is typically the
 choice for production traffic; JSON is convenient for debugging.
+
+## On a connection
+
+A connection negotiates its codec independently, so JSON and MessagePack clients can share one
+server. Pass `codec=` when opening a client; over WebSocket the choice rides on a `?codec=` query
+param, and JSON travels as text frames while MessagePack travels as binary frames.
+
+```python
+from transports import Client
+
+await Client(codec="msgpack").connect("ws://localhost:8000/ws")   # appends ?codec=msgpack
+```
+
+```javascript
+new Client("msgpack").connect("ws://localhost:8000/ws");
+```
+
+The server encodes every outbound message in *that* connection's codec and decodes inbound frames by
+type, so a MessagePack client's edit is transparently relayed to a JSON client and vice versa — see
+[Connections](connections.md). Whole protocol messages (not just model values) are converted with
+`json_to_msgpack` / `msgpack_to_json` (`jsonToMsgpack` / `msgpackToJson` in JavaScript).

--- a/docs/src/connections.md
+++ b/docs/src/connections.md
@@ -49,18 +49,25 @@ app = Starlette(
 On connect, a client receives a snapshot of every hosted model, then a stream of patches. A patch a
 client sends back is applied and relayed to the *other* clients, so the server acts as a hub.
 
+### Choosing a codec
+
+Each connection negotiates its wire format with a `?codec=` query param (`json`, the default, or
+`msgpack`). The server tracks it per connection and encodes every outbound message to match — JSON
+as text frames, MessagePack as binary frames — so JSON and MessagePack clients can share one server
+and still exchange edits. See [Codecs](codecs.md).
+
 ## Python client
 
 {py:class}`~transports.Client` mirrors a remote session without hosting it:
 
 ```python
-client = transports.Client()
+client = transports.Client()                     # or Client(codec="msgpack")
 await client.connect("ws://localhost:8000/ws")   # mirrors until the connection closes
 client.model(mid, Counter)                       # materialize the mirrored model as a Counter
 ```
 
-`Client` is also usable without a live connection — feed it messages with `recv(text)` and read with
-`value(id)` / `model(id, cls)`.
+`Client` is also usable without a live connection — feed it messages with `recv(data)` (a text or
+binary frame) and read with `value(id)` / `model(id, cls)`.
 
 ## Browser client
 

--- a/js/src/rust/lib.rs
+++ b/js/src/rust/lib.rs
@@ -39,6 +39,18 @@ pub fn decode_as(data: &[u8], codec: &str) -> Result<String, JsError> {
     transports::decode_as(data, codec).map_err(|e| JsError::new(&e))
 }
 
+/// Convert an arbitrary JSON document to MessagePack bytes (a `Uint8Array` in JS).
+#[wasm_bindgen]
+pub fn json_to_msgpack(json: &str) -> Result<Vec<u8>, JsError> {
+    transports::json_to_msgpack(json).map_err(|e| JsError::new(&e))
+}
+
+/// Convert MessagePack bytes back to a JSON document.
+#[wasm_bindgen]
+pub fn msgpack_to_json(data: &[u8]) -> Result<String, JsError> {
+    transports::msgpack_to_json(data).map_err(|e| JsError::new(&e))
+}
+
 /// In-process model store: host / mutate → patch / apply / snapshot.
 #[wasm_bindgen]
 pub struct Store {

--- a/js/src/ts/client.ts
+++ b/js/src/ts/client.ts
@@ -1,4 +1,4 @@
-import { apply } from "./index";
+import { apply, msgpackToJson } from "./index";
 
 type SnapshotMsg = {
   t: "snapshot";
@@ -15,14 +15,19 @@ type PatchMsg = {
 
 /** Mirrors a remote transports `Session` from connection messages.
  *
- * Requires the wasm core to be initialized before applying patches.
+ * Inbound frames are decoded by type — text frames are JSON, binary frames are MessagePack — so a
+ * client transparently mirrors a server regardless of the negotiated codec. Requires the wasm core
+ * to be initialized before applying patches.
  */
 export class Client {
   private values = new Map<number, unknown>();
   private revs = new Map<number, number>();
 
-  /** Apply an inbound snapshot or patch message to the local mirror. */
-  recv(text: string): void {
+  constructor(private codec: string = "json") {}
+
+  /** Apply an inbound snapshot or patch frame (string JSON or binary msgpack) to the mirror. */
+  recv(data: string | Uint8Array): void {
+    const text = typeof data === "string" ? data : msgpackToJson(data);
     const msg = JSON.parse(text) as SnapshotMsg | PatchMsg;
     if (msg.t === "snapshot") {
       this.values.set(msg.id, msg.value);
@@ -48,10 +53,15 @@ export class Client {
 
   /** Connect to a transports server and mirror it. Returns the `WebSocket`. */
   connect(url: string): WebSocket {
-    const ws = new WebSocket(url);
-    ws.addEventListener("message", (e) =>
-      this.recv(String((e as MessageEvent).data)),
-    );
+    const sep = url.includes("?") ? "&" : "?";
+    const ws = new WebSocket(`${url}${sep}codec=${this.codec}`);
+    ws.binaryType = "arraybuffer";
+    ws.addEventListener("message", (e) => {
+      const data = (e as MessageEvent).data;
+      this.recv(
+        typeof data === "string" ? data : new Uint8Array(data as ArrayBuffer),
+      );
+    });
     return ws;
   }
 }

--- a/js/src/ts/index.ts
+++ b/js/src/ts/index.ts
@@ -26,6 +26,14 @@ export const encodeAs = (model: string, codec: string): Uint8Array =>
 export const decodeAs = (bytes: Uint8Array, codec: string): string =>
   wasm.decode_as(bytes, codec);
 
+/** Convert an arbitrary JSON document to MessagePack bytes (for whole protocol messages). */
+export const jsonToMsgpack = (json: string): Uint8Array =>
+  wasm.json_to_msgpack(json);
+
+/** Convert MessagePack bytes back to a JSON document. */
+export const msgpackToJson = (bytes: Uint8Array): string =>
+  wasm.msgpack_to_json(bytes);
+
 /** In-process model store: host / mutate → patch / apply / snapshot. */
 export const Store = wasm.Store;
 

--- a/js/tests/import.test.js
+++ b/js/tests/import.test.js
@@ -6,6 +6,8 @@ import {
   fromValue,
   encodeAs,
   decodeAs,
+  jsonToMsgpack,
+  msgpackToJson,
   Client,
 } from "../src/ts/index";
 import { initSync } from "../dist/pkg/transports";
@@ -40,6 +42,41 @@ test("msgpack round-trips via encodeAs/decodeAs", async () => {
   expect(JSON.parse(decodeAs(mp, "application/msgpack"))).toEqual(
     JSON.parse(v),
   );
+});
+
+test("whole-message json<->msgpack round-trips", async () => {
+  const msg = JSON.stringify({ t: "patch", id: 7, patch: { rev: 2, ops: [] } });
+  const mp = jsonToMsgpack(msg);
+  expect(mp instanceof Uint8Array).toBe(true);
+  expect(JSON.parse(msgpackToJson(mp))).toEqual(JSON.parse(msg));
+});
+
+test("Client mirrors a binary (msgpack) snapshot then patch", async () => {
+  const c = new Client("msgpack");
+  c.recv(
+    jsonToMsgpack(
+      JSON.stringify({
+        t: "snapshot",
+        id: 1,
+        type: "Device",
+        rev: 0,
+        value: { Map: { on: { Bool: false } } },
+      }),
+    ),
+  );
+  c.recv(
+    jsonToMsgpack(
+      JSON.stringify({
+        t: "patch",
+        id: 1,
+        patch: {
+          rev: 1,
+          ops: [{ Set: { path: [{ Key: "on" }], value: { Bool: true } } }],
+        },
+      }),
+    ),
+  );
+  expect(c.value(1)).toEqual({ Map: { on: { Bool: true } } });
 });
 
 test("Client mirrors a snapshot then a patch", async () => {

--- a/rust/python/api/mod.rs
+++ b/rust/python/api/mod.rs
@@ -43,6 +43,19 @@ pub fn decode_as(data: &[u8], codec: &str) -> PyResult<String> {
     transports::decode_as(data, codec).map_err(PyValueError::new_err)
 }
 
+/// Convert an arbitrary JSON document to MessagePack bytes (for encoding whole protocol messages).
+#[pyfunction]
+pub fn json_to_msgpack<'py>(py: Python<'py>, json: &str) -> PyResult<Bound<'py, PyBytes>> {
+    let bytes = transports::json_to_msgpack(json).map_err(PyValueError::new_err)?;
+    Ok(PyBytes::new(py, &bytes))
+}
+
+/// Convert MessagePack bytes back to a JSON document.
+#[pyfunction]
+pub fn msgpack_to_json(data: &[u8]) -> PyResult<String> {
+    transports::msgpack_to_json(data).map_err(PyValueError::new_err)
+}
+
 /// In-process model store: host / mutate → patch / apply / snapshot.
 #[pyclass]
 pub struct Store {

--- a/rust/python/lib.rs
+++ b/rust/python/lib.rs
@@ -11,6 +11,8 @@ fn transports(_py: Python, m: &Bound<PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(api::decode, m)?)?;
     m.add_function(wrap_pyfunction!(api::encode_as, m)?)?;
     m.add_function(wrap_pyfunction!(api::decode_as, m)?)?;
+    m.add_function(wrap_pyfunction!(api::json_to_msgpack, m)?)?;
+    m.add_function(wrap_pyfunction!(api::msgpack_to_json, m)?)?;
     m.add_class::<api::Store>()?;
     Ok(())
 }

--- a/rust/src/bridge.rs
+++ b/rust/src/bridge.rs
@@ -52,6 +52,21 @@ pub fn decode_as(bytes: &[u8], content_type: &str) -> Result<String, String> {
     serde_json::to_string(&value).map_err(|e| e.to_string())
 }
 
+/// Convert an arbitrary JSON document to MessagePack bytes.
+///
+/// Unlike [`encode_as`], this works on *any* JSON (not just a model [`Value`]) — the connection
+/// layer uses it to encode whole protocol messages in the negotiated codec.
+pub fn json_to_msgpack(json: &str) -> Result<Vec<u8>, String> {
+    let v: serde_json::Value = serde_json::from_str(json).map_err(|e| e.to_string())?;
+    rmp_serde::to_vec_named(&v).map_err(|e| e.to_string())
+}
+
+/// Convert MessagePack bytes back to a JSON document.
+pub fn msgpack_to_json(bytes: &[u8]) -> Result<String, String> {
+    let v: serde_json::Value = rmp_serde::from_slice(bytes).map_err(|e| e.to_string())?;
+    serde_json::to_string(&v).map_err(|e| e.to_string())
+}
+
 /// A string-in/string-out facade over [`Store`] for the bindings.
 #[derive(Default)]
 pub struct JsonStore {
@@ -120,6 +135,18 @@ mod bridge_tests {
         assert_eq!(
             back,
             serde_json::from_str::<serde_json::Value>(model).unwrap()
+        );
+    }
+
+    #[test]
+    fn test_json_msgpack_round_trip() {
+        let json = r#"{"t":"patch","id":1,"patch":{"rev":2,"ops":[]}}"#;
+        let bytes = json_to_msgpack(json).unwrap();
+        let back: serde_json::Value =
+            serde_json::from_str(&msgpack_to_json(&bytes).unwrap()).unwrap();
+        assert_eq!(
+            back,
+            serde_json::from_str::<serde_json::Value>(json).unwrap()
         );
     }
 

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -22,7 +22,8 @@ mod store;
 mod value;
 
 pub use bridge::{
-    apply_json, decode_as, decode_json, diff_json, encode_as, encode_json, JsonStore,
+    apply_json, decode_as, decode_json, diff_json, encode_as, encode_json, json_to_msgpack,
+    msgpack_to_json, JsonStore,
 };
 pub use codec::{codec_for, Codec, CodecError, JsonCodec, MsgpackCodec};
 pub use diff::{apply, diff, Op, Patch, Path, PathSeg};

--- a/transports/__init__.py
+++ b/transports/__init__.py
@@ -3,7 +3,17 @@ from ._bridge import from_value, schema_of, schema_to_ts, to_value
 from .client import Client
 from .server import Server, autoflush, starlette_endpoint
 from .session import Session
-from .transports import Store, apply, decode, decode_as, diff, encode, encode_as  # compiled Rust extension (rust/python)
+from .transports import (  # compiled Rust extension (rust/python)
+    Store,
+    apply,
+    decode,
+    decode_as,
+    diff,
+    encode,
+    encode_as,
+    json_to_msgpack,
+    msgpack_to_json,
+)
 
 __version__ = "0.2.0"
 
@@ -17,6 +27,8 @@ __all__ = [
     "diff",
     "encode",
     "encode_as",
+    "json_to_msgpack",
+    "msgpack_to_json",
     # model bridge + reactive session (high-level)
     "Session",
     "to_value",

--- a/transports/client.py
+++ b/transports/client.py
@@ -7,7 +7,7 @@ network).
 """
 
 import json
-from typing import Any, Dict, List, Type
+from typing import Any, Dict, List, Type, Union
 
 from . import protocol
 from ._bridge import M, from_value
@@ -18,16 +18,19 @@ class Client:
     """Mirrors a remote `Session` — applies snapshot/patch messages to a local copy of each model.
 
     Read values with `value(id)` or materialize them with `model(id, cls)`. Drive it with a live
-    connection via `connect(url)`, or feed it messages directly with `recv(text)`."""
+    connection via `connect(url)`, or feed it messages directly with `recv(data)`. The `codec`
+    (`"json"` or `"msgpack"`) controls how outbound edits are framed; inbound frames are decoded
+    automatically from their type (text=JSON, binary=msgpack)."""
 
-    def __init__(self) -> None:
+    def __init__(self, codec: str = protocol.JSON) -> None:
         self._values: Dict[int, Any] = {}
         self._rev: Dict[int, int] = {}
         self._type: Dict[int, str] = {}
+        self._codec = protocol.normalize_codec(codec)
 
-    def recv(self, text: str) -> None:
-        """Apply an inbound snapshot or patch message to the local mirror."""
-        msg = protocol.parse(text)
+    def recv(self, data: Union[str, bytes]) -> None:
+        """Apply an inbound snapshot or patch message (text or binary frame) to the local mirror."""
+        msg = protocol.decode(data)
         mid = msg["id"]
         if msg["t"] == "snapshot":
             self._values[mid] = msg["value"]
@@ -48,18 +51,22 @@ class Client:
     def ids(self) -> List[int]:
         return list(self._values)
 
-    def edit(self, mid: int, new_value: Any) -> str:
-        """Locally edit a mirrored model and return the patch message to send to the server."""
+    def edit(self, mid: int, new_value: Any) -> Union[str, bytes]:
+        """Locally edit a mirrored model and return the patch frame to send (encoded in this codec)."""
         patch = json.loads(_diff(json.dumps(self._values[mid]), json.dumps(new_value)))
         patch["rev"] = self._rev[mid] + 1
         self._values[mid] = new_value
         self._rev[mid] = patch["rev"]
-        return protocol.patch_msg(mid, patch)
+        return protocol.encode(protocol.patch_msg(mid, patch), self._codec)
 
     async def connect(self, url: str) -> None:
-        """Connect to a transports server and mirror it until the connection closes."""
+        """Connect to a transports server and mirror it until the connection closes.
+
+        Appends ``?codec=`` for the client's codec so the server frames messages to match.
+        """
         import websockets
 
-        async with websockets.connect(url) as ws:
-            async for text in ws:
-                self.recv(text if isinstance(text, str) else text.decode())
+        sep = "&" if "?" in url else "?"
+        async with websockets.connect(f"{url}{sep}codec={self._codec}") as ws:
+            async for frame in ws:
+                self.recv(frame)

--- a/transports/protocol.py
+++ b/transports/protocol.py
@@ -11,7 +11,23 @@ Two message kinds:
 """
 
 import json
-from typing import Any
+from typing import Any, Union
+
+from .transports import json_to_msgpack as _json_to_msgpack, msgpack_to_json as _msgpack_to_json
+
+#: Canonical codec names. A connection negotiates one of these (e.g. via a ``?codec=`` query param);
+#: JSON travels as text frames, MessagePack as binary frames.
+JSON = "json"
+MSGPACK = "msgpack"
+
+
+def normalize_codec(name: Union[str, None]) -> str:
+    """Map a codec name or content-type to a canonical :data:`JSON` / :data:`MSGPACK`."""
+    if name in (None, "", "json", "application/json"):
+        return JSON
+    if name in ("msgpack", "application/msgpack", "x-msgpack", "application/x-msgpack"):
+        return MSGPACK
+    raise ValueError(f"unknown codec: {name}")
 
 
 def snapshot_msg(model_id: int, type_name: str, rev: int, value: Any) -> str:
@@ -20,6 +36,24 @@ def snapshot_msg(model_id: int, type_name: str, rev: int, value: Any) -> str:
 
 def patch_msg(model_id: int, patch: dict) -> str:
     return json.dumps({"t": "patch", "id": model_id, "patch": patch})
+
+
+def encode(msg_json: str, codec: str = JSON) -> Union[str, bytes]:
+    """Encode a JSON message string into the wire form for ``codec``.
+
+    Returns the string unchanged for JSON, or MessagePack ``bytes`` for the msgpack codec — so the
+    caller sends a text frame or a binary frame accordingly.
+    """
+    if normalize_codec(codec) == MSGPACK:
+        return _json_to_msgpack(msg_json)
+    return msg_json
+
+
+def decode(data: Union[str, bytes]) -> dict:
+    """Parse an inbound frame to a message dict, dispatching on frame type (str=JSON, bytes=msgpack)."""
+    if isinstance(data, (bytes, bytearray)):
+        return json.loads(_msgpack_to_json(bytes(data)))
+    return json.loads(data)
 
 
 def parse(text: str) -> dict:

--- a/transports/server.py
+++ b/transports/server.py
@@ -6,80 +6,106 @@ to send, keyed by connection. The actual async I/O lives in a thin adapter (`sta
 `autoflush`), so the protocol is testable without a network.
 
 A connection handle is any hashable object (the Starlette `WebSocket`, a test sentinel, ...) that the
-I/O adapter knows how to send on.
+I/O adapter knows how to send on. Each connection negotiates a codec (`"json"` or `"msgpack"`); the
+server encodes every outbound message in *that connection's* codec, so JSON and MessagePack clients
+can share one server. A wire message is a `str` (JSON text frame) or `bytes` (MessagePack binary).
 """
 
 import asyncio
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Union
 
 from . import protocol
 from .session import Session
+
+Wire = Union[str, bytes]
 
 
 class Server:
     """Serves a `Session` to connected clients: sends a snapshot on connect, broadcasts patches, and
     relays a client's patches to the other clients (a hub). Transport-agnostic — its methods return
-    the messages to send; an adapter such as `starlette_endpoint` performs the I/O."""
+    the messages to send; an adapter such as `starlette_endpoint` performs the I/O.
+
+    Each connection has its own negotiated codec, so outbound messages are encoded per connection."""
 
     def __init__(self, session: Session) -> None:
         self._session = session
-        self._conns: set = set()
+        self._codecs: Dict[Any, str] = {}
 
-    def open(self, conn: Any) -> List[str]:
-        """Register a connection; returns the snapshot messages to send it (current model state)."""
-        self._conns.add(conn)
-        out: List[str] = []
+    def _encode_for(self, conn: Any, msg_json: str) -> Wire:
+        return protocol.encode(msg_json, self._codecs.get(conn, protocol.JSON))
+
+    def open(self, conn: Any, codec: str = protocol.JSON) -> List[Wire]:
+        """Register a connection with its codec; returns the snapshot messages to send it."""
+        self._codecs[conn] = protocol.normalize_codec(codec)
+        out: List[Wire] = []
         for mid in self._session.ids():
             snap = self._session.snapshot(mid)
-            out.append(protocol.snapshot_msg(mid, snap["type_name"], snap["rev"], snap["value"]))
+            msg = protocol.snapshot_msg(mid, snap["type_name"], snap["rev"], snap["value"])
+            out.append(self._encode_for(conn, msg))
         return out
 
-    def recv(self, conn: Any, text: str) -> Dict[Any, List[str]]:
-        """Handle an inbound message; returns messages to send, keyed by connection.
+    def recv(self, conn: Any, data: Wire) -> Dict[Any, List[Wire]]:
+        """Handle an inbound message (text or binary frame); returns messages to send, keyed by conn.
 
         A client patch is applied to the hosted model's value and relayed to the *other* connections,
-        so the server acts as a hub.
+        so the server acts as a hub. Each relay is encoded in the target connection's codec.
         """
-        msg = protocol.parse(text)
+        msg = protocol.decode(data)
         if msg.get("t") == "patch":
             self._session.apply_patch(msg["id"], msg["patch"])
             relay = protocol.patch_msg(msg["id"], msg["patch"])
-            return {c: [relay] for c in self._conns if c is not conn}
+            return {c: [self._encode_for(c, relay)] for c in self._codecs if c is not conn}
         return {}
 
-    def flush(self) -> Dict[Any, List[str]]:
-        """Drain the session and return the patch messages to broadcast to every connection."""
+    def flush(self) -> Dict[Any, List[Wire]]:
+        """Drain the session and return the patch messages to broadcast, encoded per connection."""
         msgs = [protocol.patch_msg(mid, patch) for mid, patch in self._session.drain()]
-        if not msgs or not self._conns:
+        if not msgs or not self._codecs:
             return {}
-        return {c: list(msgs) for c in self._conns}
+        return {c: [self._encode_for(c, m) for m in msgs] for c in self._codecs}
 
     def close(self, conn: Any) -> None:
-        self._conns.discard(conn)
+        self._codecs.pop(conn, None)
 
 
 # --- async I/O adapters --------------------------------------------------------------------------
 
 
+async def _send(conn: Any, msg: Wire) -> None:
+    if isinstance(msg, (bytes, bytearray)):
+        await conn.send_bytes(msg)
+    else:
+        await conn.send_text(msg)
+
+
 def starlette_endpoint(server: Server):
     """Build a Starlette WebSocket endpoint that serves `server`.
 
-    Wire it into an app, e.g. ``WebSocketRoute("/ws", starlette_endpoint(server))``, and run
-    `autoflush(server)` as a background task to stream server-side model changes to clients.
+    The connection's codec is read from a ``?codec=`` query param (default JSON). Wire it into an
+    app, e.g. ``WebSocketRoute("/ws", starlette_endpoint(server))``, and run `autoflush(server)` as a
+    background task to stream server-side model changes to clients.
     """
 
     async def endpoint(websocket: Any) -> None:
         from starlette.websockets import WebSocketDisconnect
 
+        codec = websocket.query_params.get("codec", protocol.JSON)
         await websocket.accept()
-        for msg in server.open(websocket):
-            await websocket.send_text(msg)
+        for msg in server.open(websocket, codec):
+            await _send(websocket, msg)
         try:
             while True:
-                text = await websocket.receive_text()
-                for conn, msgs in server.recv(websocket, text).items():
+                frame = await websocket.receive()
+                if frame.get("type") == "websocket.disconnect":
+                    break
+                data = frame.get("text")
+                if data is None:
+                    data = frame.get("bytes")
+                if data is None:
+                    continue
+                for conn, msgs in server.recv(websocket, data).items():
                     for msg in msgs:
-                        await conn.send_text(msg)
+                        await _send(conn, msg)
         except WebSocketDisconnect:
             pass
         finally:
@@ -98,6 +124,6 @@ async def autoflush(server: Server, interval: float = 0.01) -> None:
         for conn, msgs in server.flush().items():
             for msg in msgs:
                 try:
-                    await conn.send_text(msg)
+                    await _send(conn, msg)
                 except Exception:
                     server.close(conn)

--- a/transports/tests/test_codec.py
+++ b/transports/tests/test_codec.py
@@ -2,7 +2,7 @@ import json
 
 import pytest
 
-from transports import decode_as, encode, encode_as
+from transports import decode_as, encode, encode_as, json_to_msgpack, msgpack_to_json, protocol
 
 MODEL = json.dumps({"Map": {"name": {"Str": "lamp"}, "on": {"Bool": True}, "count": {"Int": 123456}}})
 
@@ -24,3 +24,33 @@ def test_json_via_encode_as_matches_encode():
 def test_unknown_codec_raises():
     with pytest.raises(ValueError):
         encode_as(MODEL, "application/protobuf")
+
+
+# --- whole-message JSON <-> msgpack (protocol framing) -------------------------------------------
+
+MSG = json.dumps({"t": "patch", "id": 7, "patch": {"rev": 2, "ops": []}})
+
+
+def test_json_msgpack_message_round_trip():
+    blob = json_to_msgpack(MSG)
+    assert isinstance(blob, bytes)
+    assert json.loads(msgpack_to_json(blob)) == json.loads(MSG)
+
+
+def test_protocol_encode_decode_json():
+    wire = protocol.encode(MSG, protocol.JSON)
+    assert isinstance(wire, str)
+    assert protocol.decode(wire) == json.loads(MSG)
+
+
+def test_protocol_encode_decode_msgpack():
+    wire = protocol.encode(MSG, protocol.MSGPACK)
+    assert isinstance(wire, bytes)
+    assert protocol.decode(wire) == json.loads(MSG)
+
+
+def test_normalize_codec_aliases():
+    assert protocol.normalize_codec("application/msgpack") == protocol.MSGPACK
+    assert protocol.normalize_codec(None) == protocol.JSON
+    with pytest.raises(ValueError):
+        protocol.normalize_codec("application/protobuf")

--- a/transports/tests/test_connection.py
+++ b/transports/tests/test_connection.py
@@ -80,6 +80,96 @@ def test_flush_without_connections_is_empty():
     assert server.flush() == {}
 
 
+# --- codec negotiation ---------------------------------------------------------------------------
+
+
+def test_msgpack_connection_mirrors_with_binary_frames():
+    session = Session()
+    server = Server(session)
+    client = Client(codec="msgpack")
+    d = Device(name="lamp")
+    mid = session.host(d)
+
+    snaps = server.open("c1", codec="msgpack")
+    assert all(isinstance(m, bytes) for m in snaps)  # binary frames over the wire
+    for m in snaps:
+        client.recv(m)
+    assert client.model(mid, Device) == d
+
+    d.on = True
+    out = server.flush()["c1"]
+    assert all(isinstance(m, bytes) for m in out)
+    for m in out:
+        client.recv(m)
+    assert client.model(mid, Device).on is True
+
+
+def test_mixed_codecs_per_connection():
+    session = Session()
+    server = Server(session)
+    j, m = Client(), Client(codec="msgpack")
+    d = Device(name="lamp")
+    mid = session.host(d)
+    for msg in server.open("j"):
+        j.recv(msg)
+    for msg in server.open("m", codec="msgpack"):
+        m.recv(msg)
+
+    d.name = "desk"
+    out = server.flush()
+    assert all(isinstance(x, str) for x in out["j"])  # JSON client gets text
+    assert all(isinstance(x, bytes) for x in out["m"])  # msgpack client gets binary
+    for msg in out["j"]:
+        j.recv(msg)
+    for msg in out["m"]:
+        m.recv(msg)
+    assert j.model(mid, Device).name == "desk"
+    assert m.model(mid, Device).name == "desk"
+
+
+def test_msgpack_client_edit_relays_to_json_client():
+    session = Session()
+    server = Server(session)
+    j, m = Client(), Client(codec="msgpack")
+    d = Device(name="lamp")
+    mid = session.host(d)
+    for msg in server.open("j"):
+        j.recv(msg)
+    for msg in server.open("m", codec="msgpack"):
+        m.recv(msg)
+
+    edit = m.edit(mid, to_value(Device(name="lamp", on=True)))  # msgpack client edits (binary frame)
+    assert isinstance(edit, bytes)
+    out = server.recv("m", edit)
+    assert set(out) == {"j"}
+    for msg in out["j"]:  # relayed to the JSON client, re-encoded as text
+        assert isinstance(msg, str)
+        j.recv(msg)
+    assert j.model(mid, Device).on is True
+
+
+def test_starlette_msgpack_connection():
+    from starlette.applications import Starlette
+    from starlette.routing import WebSocketRoute
+    from starlette.testclient import TestClient
+
+    session = Session()
+    server = Server(session)
+    d = Device(name="lamp")
+    mid = session.host(d)
+    app = Starlette(routes=[WebSocketRoute("/ws", starlette_endpoint(server))])
+
+    with TestClient(app) as tc, tc.websocket_connect("/ws?codec=msgpack") as ws:
+        client = Client(codec="msgpack")
+        client.recv(ws.receive_bytes())  # snapshot as a binary frame
+        assert client.model(mid, Device) == d
+
+        # client edits and sends a binary frame; server applies it
+        edit = client.edit(mid, to_value(Device(name="lamp", on=True)))
+        assert isinstance(edit, bytes)
+        ws.send_bytes(edit)
+
+
 # --- real Starlette WebSocket I/O ----------------------------------------------------------------
 
 

--- a/transports/transports.pyi
+++ b/transports/transports.pyi
@@ -18,6 +18,12 @@ def encode_as(value: str, codec: str) -> bytes:
 def decode_as(data: bytes, codec: str) -> str:
     """Decode bytes (from `codec`'s codec) back to a JSON-encoded model string."""
 
+def json_to_msgpack(json: str) -> bytes:
+    """Convert an arbitrary JSON document to MessagePack bytes."""
+
+def msgpack_to_json(data: bytes) -> str:
+    """Convert MessagePack bytes back to a JSON document."""
+
 class Store:
     """In-process model store: host / mutate -> patch / apply / snapshot."""
 


### PR DESCRIPTION
Lets a WebSocket carry MessagePack **end-to-end**, not just JSON.

## What

Each connection negotiates its codec with a `?codec=` query param (`json` default, or `msgpack`). The `Server` tracks `conn → codec` and:

- encodes every outbound message in *that* connection's codec — JSON as **text** frames, MessagePack as **binary** frames;
- decodes inbound frames by type (`str` = JSON, `bytes` = msgpack).

So JSON and MessagePack clients can share one server, and an edit from a MessagePack client is transparently re-encoded for a JSON client (and vice versa).

## How

- **Core:** generic `json_to_msgpack` / `msgpack_to_json` (operate on *whole protocol messages*, not just model `Value`s, via `serde_json::Value` ↔ `rmp_serde`), exposed through both the PyO3 and wasm bindings.
- **`protocol.py`:** `JSON`/`MSGPACK` constants, `normalize_codec`, `encode(msg_json, codec) -> str | bytes`, `decode(str | bytes) -> dict`.
- **`Server`:** per-connection codec; `open(conn, codec)` and per-target encoding for `recv`/`flush`. `starlette_endpoint` reads the query param and uses `receive()` / `send_text` / `send_bytes`.
- **Clients:** `Client(codec=...)` in Python and JS; both decode inbound frames by type and frame outbound edits in their codec; `connect()` appends `?codec=`.

## Tests

- Rust: whole-message msgpack round-trip.
- Python: codec round-trip + protocol encode/decode; msgpack loopback, mixed-codec broadcast, cross-codec relay, and a real Starlette msgpack connection.
- JS: playwright whole-message round-trip + a binary (msgpack) `Client`.

All green: 29 Rust, 37 Python, 7 Playwright; ty / ruff / clippy / fmt / prettier clean. Docs updated (`codecs.md`, `connections.md`, `api.md`).