### PR TITLE
Add a multi-tenant Hub with shared data structures and a merge seam

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -41,6 +41,24 @@ The high-level reactive session, the model bridge, the connection adapters, and 
 .. autofunction:: transports.autoflush
 ```
 
+## Multi-tenancy & sharing
+
+```{eval-rst}
+.. autoclass:: transports.Hub
+   :members:
+   :undoc-members:
+   :member-order: bysource
+
+.. autoclass:: transports.MergeStrategy
+   :members:
+
+.. autoclass:: transports.LastWriteWins
+   :members:
+
+.. autoclass:: transports.LwwMapCrdt
+   :members:
+```
+
 ## Core
 
 The low-level surface, exposed directly from the Rust core. Most users work through

--- a/docs/src/multitenancy.md
+++ b/docs/src/multitenancy.md
@@ -1,0 +1,86 @@
+# Multi-tenancy & sharing
+
+A single process often serves many independent tenants, and some data is **shared** between them. A
+{py:class}`~transports.Hub` handles both: it routes each connection to its tenant and lets any number
+of tenants subscribe to a shared data structure.
+
+## Tenants
+
+Each tenant's models live in their own {py:class}`~transports.Session`, so tenants are fully
+isolated — one tenant never sees another's models. The `Hub` maps a connection to a tenant with a
+`key` function you provide:
+
+```python
+import transports
+
+hub = transports.Hub(key=lambda ws: ws.path_params["tenant"])
+
+# a tenant's private models
+hub.tenant("alice").host(Document(title="notes"))
+```
+
+A connection only ever receives its own tenant's private models (plus any shared models it
+subscribes to), and a private edit is relayed only to that tenant's other connections.
+
+## Shared data structures
+
+A **shared** model's authoritative state lives in the hub. Register it with `share()`, then connect
+tenants to it with `subscribe()` and an access mode — `READ` or `WRITE`. The sharing shape is just
+the set of subscriptions:
+
+```python
+from transports import READ, WRITE
+
+doc = hub.share(Document(title="roadmap"))   # returns a shared id
+hub.subscribe("alice", doc, WRITE)
+hub.subscribe("bob", doc, READ)              # bob mirrors it but cannot write
+```
+
+- **One model, many readers** — subscribe many tenants `READ` (broadcast / fan-out).
+- **Many writers, one model** — subscribe many tenants `WRITE` (collaborative editing).
+- **Many models, many tenants** — any mix of the above; each connection receives exactly the models
+  it subscribes to.
+
+Shared models are **server-authoritative**: a writer sends its edit and receives the reconciled
+patch back, and every subscriber is kept in sync. Write to a shared model from the host side with
+`set_shared(id, value)`; the change is broadcast on the next flush.
+
+## Reconciling concurrent writes
+
+When several tenants write the same shared model, a {py:class}`~transports.MergeStrategy` decides how
+the writes combine. Pass one per shared model:
+
+```python
+from transports import LastWriteWins, LwwMapCrdt
+
+hub.share(Document(), merge=LastWriteWins)   # default: apply writes in arrival order
+hub.share(Document(), merge=LwwMapCrdt)      # conflict-free per-field resolution
+```
+
+- {py:class}`~transports.LastWriteWins` (the default) applies each write as it arrives.
+- {py:class}`~transports.LwwMapCrdt` resolves per top-level field: concurrent edits to *different*
+  fields both survive, and conflicting edits to the *same* field converge to the same value
+  regardless of the order the writes arrive in.
+
+To plug in your own reconciliation, implement `merge(current, patch, origin) -> value` and pass the
+class to `share(merge=...)`.
+
+## Serving it
+
+`Hub.endpoint()` adapts the hub to a Starlette WebSocket route, reusing the same per-connection
+[codec negotiation](codecs.md) as a single-tenant server. Run one
+{py:func}`~transports.autoflush` task to stream host-side changes to every connection.
+
+```python
+import asyncio
+from starlette.applications import Starlette
+from starlette.routing import WebSocketRoute
+
+app = Starlette(
+    routes=[WebSocketRoute("/ws/{tenant}", hub.endpoint())],
+    on_startup=[lambda: asyncio.create_task(transports.autoflush(hub))],
+)
+```
+
+On the client side nothing changes — a {py:class}`~transports.Client` mirrors whatever models the
+hub sends it, private or shared.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -227,6 +227,7 @@ pages = [
     "docs/src/bridges.md",
     "docs/src/connections.md",
     "docs/src/codecs.md",
+    "docs/src/multitenancy.md",
     "docs/src/api.md",
 ]
 exclude_patterns = [

--- a/transports/__init__.py
+++ b/transports/__init__.py
@@ -1,6 +1,7 @@
 from . import protocol
 from ._bridge import from_value, schema_of, schema_to_ts, to_value
 from .client import Client
+from .hub import READ, WRITE, Hub, LastWriteWins, LwwMapCrdt, MergeStrategy
 from .server import Server, autoflush, starlette_endpoint
 from .session import Session
 from .transports import (  # compiled Rust extension (rust/python)
@@ -41,4 +42,11 @@ __all__ = [
     "starlette_endpoint",
     "autoflush",
     "protocol",
+    # multi-tenancy + sharing
+    "Hub",
+    "READ",
+    "WRITE",
+    "MergeStrategy",
+    "LastWriteWins",
+    "LwwMapCrdt",
 ]

--- a/transports/hub.py
+++ b/transports/hub.py
@@ -1,0 +1,295 @@
+"""Multi-tenant hub: route many connections to many tenant sessions, and share data structures.
+
+A `Hub` serves many tenants from one process. Each connection is mapped to a **tenant** by an
+app-supplied `key(conn)`; a tenant's *private* models live in its own isolated `Session` (so tenants
+never see each other's data). On top of that, a hub hosts **shared data structures** — models whose
+authoritative state lives in the hub and which any number of tenants can *subscribe* to with an
+access **mode** (`READ` or `WRITE`). The sharing cardinalities fall out of the subscription edges:
+
+- **1-N** — one shared model, many `READ` subscribers (broadcast / fan-out).
+- **N-1 / N-N** — many `WRITE` subscribers on one (or many) shared models (collaborative editing).
+
+Writes to a shared model are reconciled by a pluggable :class:`MergeStrategy` (default
+:class:`LastWriteWins`; :class:`LwwMapCrdt` is a conflict-free reference). Like `Server`, the hub's
+logic is synchronous and transport-agnostic — its methods *return* the messages to send, keyed by
+connection — so it is unit-testable without a network; `Hub.endpoint()` adapts it to Starlette.
+
+Shared models are **server-authoritative**: a writer sends its edit and receives the authoritative
+patch back.
+"""
+
+import json
+from typing import Any, Callable, Dict, List, Optional, Union
+
+from . import protocol
+from ._bridge import to_value
+from .server import Wire, _send
+from .session import Session
+from .transports import apply as _apply, diff as _diff
+
+READ = "read"
+WRITE = "write"
+
+#: Shared-model wire ids live above this base so they never collide with per-`Session` model ids
+#: (which start at 1 in each tenant's own store).
+SHARED_ID_BASE = 1 << 40
+
+
+# --- merge strategies ----------------------------------------------------------------------------
+
+
+class MergeStrategy:
+    """How a write to a shared model is reconciled into its authoritative value.
+
+    `merge(current, patch, origin)` returns the new core `Value`. Implementations may be stateful;
+    pass the **class** (not an instance) to `Hub.share(merge=...)` so each shared model gets its own
+    instance and its own state.
+    """
+
+    def merge(self, current: Any, patch: dict, origin: Any) -> Any:  # pragma: no cover - interface
+        raise NotImplementedError
+
+
+class LastWriteWins(MergeStrategy):
+    """Apply each write in arrival order (today's `Store` semantics). Order-dependent."""
+
+    def merge(self, current: Any, patch: dict, origin: Any) -> Any:
+        return json.loads(_apply(json.dumps(current), json.dumps(patch)))
+
+
+class LwwMapCrdt(MergeStrategy):
+    """Conflict-free per-top-level-key last-writer-wins register map.
+
+    Each top-level map key carries a logical stamp `(patch rev, origin)`; a key's write is accepted
+    only if its stamp is at least the stored one. Two consequences: concurrent edits to *different*
+    keys both survive, and conflicting edits to the *same* key converge to the same value regardless
+    of the order the hub happens to receive them in (the stamp is intrinsic to the write, not its
+    arrival order). Nested or list ops fall back to a direct apply, stamped by their top-level key.
+    """
+
+    def __init__(self) -> None:
+        self._clock: Dict[str, tuple] = {}
+
+    def merge(self, current: Any, patch: dict, origin: Any) -> Any:
+        new = json.loads(json.dumps(current))
+        mp = new.get("Map") if isinstance(new, dict) else None
+        if mp is None:  # not a map model — fall back to whole-value LWW
+            return json.loads(_apply(json.dumps(current), json.dumps(patch)))
+        rev = patch.get("rev", 0)
+        stamp = (rev, str(origin))
+        for op in patch.get("ops", []):
+            kind = next(iter(op))
+            body = op[kind]
+            path = body.get("path", [])
+            top = path[0]["Key"] if path and "Key" in path[0] else None
+            if top is None:  # unattributable to a key (e.g. whole-model op) — apply as-is
+                new = json.loads(_apply(json.dumps(new), json.dumps({"rev": rev, "ops": [op]})))
+                mp = new.get("Map")
+                continue
+            if top in self._clock and stamp < self._clock[top]:
+                continue  # stale write — drop
+            self._clock[top] = stamp
+            if len(path) == 1 and kind == "Set":
+                mp[top] = body["value"]
+            elif len(path) == 1 and kind == "Remove":
+                mp.pop(top, None)
+            else:  # nested op under `top` — apply to the whole value, then refresh the map handle
+                new = json.loads(_apply(json.dumps(new), json.dumps({"rev": rev, "ops": [op]})))
+                mp = new.get("Map")
+        return new
+
+
+# --- hub ------------------------------------------------------------------------------------------
+
+
+class _Shared:
+    """Authoritative state for a shared data structure."""
+
+    def __init__(self, type_name: str, value: dict, merge: MergeStrategy) -> None:
+        self.type_name = type_name
+        self.value = value
+        self.rev = 0
+        self.merge = merge
+        self.subs: Dict[Any, str] = {}  # tenant key -> mode
+
+
+class Hub:
+    """Route connections to per-tenant `Session` objects and fan shared data structures to subscribers.
+
+    Construct with `key`, a function mapping a connection handle to its tenant key. Register shared
+    models with `share()` and connect tenants to them with `subscribe()`. Like `Server`, the methods
+    return the messages to send keyed by connection; `endpoint()` performs the I/O over Starlette.
+    """
+
+    def __init__(self, key: Callable[[Any], Any], *, default_codec: str = protocol.JSON) -> None:
+        self._key = key
+        self._default_codec = protocol.normalize_codec(default_codec)
+        self._tenants: Dict[Any, Session] = {}
+        self._shared: Dict[int, _Shared] = {}
+        self._next_shared = 0
+        self._conn_key: Dict[Any, Any] = {}
+        self._codecs: Dict[Any, str] = {}
+        self._shared_outbox: List[tuple] = []  # (sid, fan_patch) from host-side writes
+
+    # --- registration ----------------------------------------------------------------------------
+
+    def tenant(self, key: Any) -> Session:
+        """Get (or create) the `Session` holding a tenant's private models."""
+        sess = self._tenants.get(key)
+        if sess is None:
+            sess = self._tenants[key] = Session()
+        return sess
+
+    def share(self, model_or_value: Any, type_name: Optional[str] = None, *, merge: Any = LastWriteWins) -> int:
+        """Register a shared data structure; returns its shared id.
+
+        Pass a model instance (pydantic/dataclass/msgspec) to capture its value and type name, or a
+        core `Value` dict together with `type_name`. `merge` is a `MergeStrategy` subclass (each
+        shared model gets its own instance) or an instance to reuse.
+        """
+        if type_name is None:
+            type_name = type(model_or_value).__name__
+            value = to_value(model_or_value)
+        else:
+            value = model_or_value
+        strategy = merge() if isinstance(merge, type) else merge
+        sid = SHARED_ID_BASE + self._next_shared
+        self._next_shared += 1
+        self._shared[sid] = _Shared(type_name, value, strategy)
+        return sid
+
+    def subscribe(self, tenant_key: Any, sid: int, mode: str = READ) -> None:
+        """Subscribe a tenant to a shared model with `READ` or `WRITE` access."""
+        if mode not in (READ, WRITE):
+            raise ValueError(f"unknown mode: {mode}")
+        self.tenant(tenant_key)  # ensure the tenant exists
+        self._shared[sid].subs[tenant_key] = mode
+
+    # --- per-connection encoding -----------------------------------------------------------------
+
+    def _encode_for(self, conn: Any, msg_json: str) -> Wire:
+        return protocol.encode(msg_json, self._codecs.get(conn, self._default_codec))
+
+    # --- connection lifecycle --------------------------------------------------------------------
+
+    def open(self, conn: Any, codec: Optional[str] = None) -> List[Wire]:
+        """Register a connection; returns the snapshots of its tenant's private + subscribed shared models."""
+        key = self._key(conn)
+        self._conn_key[conn] = key
+        self._codecs[conn] = protocol.normalize_codec(codec or self._default_codec)
+        sess = self.tenant(key)
+        out: List[Wire] = []
+        for mid in sess.ids():
+            snap = sess.snapshot(mid)
+            out.append(self._encode_for(conn, protocol.snapshot_msg(mid, snap["type_name"], snap["rev"], snap["value"])))
+        for sid, sh in self._shared.items():
+            if key in sh.subs:
+                out.append(self._encode_for(conn, protocol.snapshot_msg(sid, sh.type_name, sh.rev, sh.value)))
+        return out
+
+    def recv(self, conn: Any, data: Wire) -> Dict[Any, List[Wire]]:
+        """Handle an inbound patch; returns messages to send, keyed by connection.
+
+        A patch to a private model is applied to the tenant's session and relayed to that tenant's
+        *other* connections. A patch to a shared model (from a `WRITE` subscriber) is merged into the
+        authoritative value and the resulting patch is broadcast to every subscriber connection.
+        """
+        msg = protocol.decode(data)
+        if msg.get("t") != "patch":
+            return {}
+        wire_id = msg["id"]
+        key = self._conn_key.get(conn)
+        if wire_id >= SHARED_ID_BASE:
+            sh = self._shared.get(wire_id)
+            if sh is None or sh.subs.get(key) != WRITE:
+                return {}  # unknown shared model, or this tenant may not write it
+            fan = self._write_shared(wire_id, msg["patch"], origin=key)
+            return self._fanout(wire_id, fan) if fan else {}
+        sess = self._tenants.get(key)
+        if sess is None:
+            return {}
+        sess.apply_patch(wire_id, msg["patch"])
+        relay = protocol.patch_msg(wire_id, msg["patch"])
+        return {c: [self._encode_for(c, relay)] for c, k in self._conn_key.items() if k == key and c is not conn}
+
+    def flush(self) -> Dict[Any, List[Wire]]:
+        """Drain every tenant session and any host-side shared writes; route the patches per tenant/subscription."""
+        out: Dict[Any, List[Wire]] = {}
+        for key, sess in self._tenants.items():
+            drained = sess.drain()
+            if not drained:
+                continue
+            conns = [c for c, k in self._conn_key.items() if k == key]
+            for c in conns:
+                for mid, patch in drained:
+                    out.setdefault(c, []).append(self._encode_for(c, protocol.patch_msg(mid, patch)))
+        for sid, fan in self._shared_outbox:
+            for c, msgs in self._fanout(sid, fan).items():
+                out.setdefault(c, []).extend(msgs)
+        self._shared_outbox.clear()
+        return out
+
+    def set_shared(self, sid: int, new_value_or_model: Any) -> None:
+        """Write to a shared model from the host side; the change is broadcast on the next `flush()`."""
+        value = new_value_or_model if isinstance(new_value_or_model, dict) else to_value(new_value_or_model)
+        patch = json.loads(_diff(json.dumps(self._shared[sid].value), json.dumps(value)))
+        if not patch["ops"]:
+            return
+        fan = self._write_shared(sid, patch, origin="<host>")
+        if fan:
+            self._shared_outbox.append((sid, fan))
+
+    def close(self, conn: Any) -> None:
+        self._conn_key.pop(conn, None)
+        self._codecs.pop(conn, None)
+
+    # --- shared write internals ------------------------------------------------------------------
+
+    def _write_shared(self, sid: int, patch: dict, origin: Any) -> Optional[dict]:
+        """Merge a write into a shared model; return the authoritative fan-out patch (or None)."""
+        sh = self._shared[sid]
+        new = sh.merge.merge(sh.value, patch, origin)
+        fan = json.loads(_diff(json.dumps(sh.value), json.dumps(new)))
+        if not fan["ops"]:
+            return None
+        sh.value = new
+        sh.rev += 1
+        fan["rev"] = sh.rev
+        return fan
+
+    def _fanout(self, sid: int, fan: dict) -> Dict[Any, List[Wire]]:
+        sh = self._shared[sid]
+        msg = protocol.patch_msg(sid, fan)
+        return {c: [self._encode_for(c, msg)] for c, k in self._conn_key.items() if k in sh.subs}
+
+    # --- async I/O adapter -----------------------------------------------------------------------
+
+    def endpoint(self):
+        """Build a Starlette WebSocket endpoint that serves this hub (tenant from `key(websocket)`)."""
+
+        async def endpoint(websocket: Any) -> None:
+            from starlette.websockets import WebSocketDisconnect
+
+            codec = websocket.query_params.get("codec", self._default_codec)
+            await websocket.accept()
+            for msg in self.open(websocket, codec):
+                await _send(websocket, msg)
+            try:
+                while True:
+                    frame = await websocket.receive()
+                    if frame.get("type") == "websocket.disconnect":
+                        break
+                    payload: Union[str, bytes, None] = frame.get("text")
+                    if payload is None:
+                        payload = frame.get("bytes")
+                    if payload is None:
+                        continue
+                    for conn, msgs in self.recv(websocket, payload).items():
+                        for msg in msgs:
+                            await _send(conn, msg)
+            except WebSocketDisconnect:
+                pass
+            finally:
+                self.close(websocket)
+
+        return endpoint

--- a/transports/server.py
+++ b/transports/server.py
@@ -12,12 +12,20 @@ can share one server. A wire message is a `str` (JSON text frame) or `bytes` (Me
 """
 
 import asyncio
-from typing import Any, Dict, List, Union
+from typing import Any, Dict, List, Protocol, Union
 
 from . import protocol
 from .session import Session
 
 Wire = Union[str, bytes]
+
+
+class Broadcaster(Protocol):
+    """The structural contract `autoflush` drives — satisfied by both `Server` and `Hub`."""
+
+    def flush(self) -> Dict[Any, List[Wire]]: ...
+
+    def close(self, conn: Any) -> None: ...
 
 
 class Server:
@@ -114,10 +122,11 @@ def starlette_endpoint(server: Server):
     return endpoint
 
 
-async def autoflush(server: Server, interval: float = 0.01) -> None:
-    """Background task: periodically flush the session and broadcast patches to all connections.
+async def autoflush(server: Broadcaster, interval: float = 0.01) -> None:
+    """Background task: periodically flush and broadcast patches to all connections.
 
-    Run exactly one of these per `Server` (not per connection), so a single drain feeds every client.
+    Run exactly one of these per `Server`/`Hub` (not per connection), so a single drain feeds every
+    client.
     """
     while True:
         await asyncio.sleep(interval)

--- a/transports/tests/test_hub.py
+++ b/transports/tests/test_hub.py
@@ -1,0 +1,190 @@
+from pydantic import BaseModel
+
+from transports import READ, WRITE, Client, Hub, LastWriteWins, LwwMapCrdt
+
+
+class Doc(BaseModel):
+    x: int = 0
+    y: int = 0
+
+
+# Connection handles are (tenant, name); the hub keys tenants off the first element.
+def hub() -> Hub:
+    return Hub(key=lambda c: c[0])
+
+
+# --- tenant routing + isolation ------------------------------------------------------------------
+
+
+def test_private_models_are_tenant_isolated():
+    h = hub()
+    h.tenant("t1").host(Doc(x=1))
+    h.tenant("t2").host(Doc(x=2))
+
+    a = h.open(("t1", "a"))
+    b = h.open(("t2", "b"))
+    ca, cb = Client(), Client()
+    for m in a:
+        ca.recv(m)
+    for m in b:
+        cb.recv(m)
+
+    # each connection sees only its own tenant's private model (both numbered id 1, never shared)
+    assert ca.model(1, Doc).x == 1
+    assert cb.model(1, Doc).x == 2
+
+
+def test_private_edit_relays_only_within_tenant():
+    h = hub()
+    h.tenant("t1").host(Doc())
+    a1, a2, b = ("t1", "a1"), ("t1", "a2"), ("t2", "b")
+    h.open(a1)
+    h.open(b)
+    ca2 = Client()
+    for m in h.open(a2):
+        ca2.recv(m)
+
+    edit = '{"t":"patch","id":1,"patch":{"rev":1,"ops":[{"Set":{"path":[{"Key":"x"}],"value":{"Int":7}}}]}}'
+    out = h.recv(a1, edit)
+    assert set(out) == {a2}  # relayed to the other connection in t1, not to t2
+    for m in out[a2]:
+        ca2.recv(m)
+    assert ca2.value(1)["Map"]["x"] == {"Int": 7}
+
+
+# --- 1-N: one shared model, many READ subscribers ------------------------------------------------
+
+
+def test_shared_read_fanout_to_many_tenants():
+    h = hub()
+    sid = h.share(Doc())
+    h.subscribe("t1", sid, READ)
+    h.subscribe("t2", sid, READ)
+    c1, c2 = ("t1", "a"), ("t2", "b")
+    cl1, cl2 = Client(), Client()
+    for m in h.open(c1):
+        cl1.recv(m)
+    for m in h.open(c2):
+        cl2.recv(m)
+
+    h.set_shared(sid, {"Map": {"x": {"Int": 3}, "y": {"Int": 0}}})  # host write
+    out = h.flush()
+    assert set(out) == {c1, c2}  # broadcast to every subscriber
+    for m in out[c1]:
+        cl1.recv(m)
+    for m in out[c2]:
+        cl2.recv(m)
+    assert cl1.value(sid)["Map"]["x"] == {"Int": 3}
+    assert cl2.value(sid)["Map"]["x"] == {"Int": 3}
+
+
+def test_read_only_subscriber_cannot_write():
+    h = hub()
+    sid = h.share(Doc())
+    h.subscribe("t1", sid, READ)
+    c = ("t1", "a")
+    h.open(c)
+    edit = '{"t":"patch","id":%d,"patch":{"rev":1,"ops":[{"Set":{"path":[{"Key":"x"}],"value":{"Int":9}}}]}}' % sid
+    assert h.recv(c, edit) == {}  # write ignored
+    assert h._shared[sid].value["Map"]["x"] == {"Int": 0}  # authoritative value untouched
+
+
+# --- N-1 / N-N: many WRITE subscribers -----------------------------------------------------------
+
+
+def test_shared_write_relays_to_other_writers():
+    h = hub()
+    sid = h.share(Doc())
+    h.subscribe("t1", sid, WRITE)
+    h.subscribe("t2", sid, WRITE)
+    c1, c2 = ("t1", "a"), ("t2", "b")
+    cl1, cl2 = Client(), Client()
+    for m in h.open(c1):
+        cl1.recv(m)
+    for m in h.open(c2):
+        cl2.recv(m)
+
+    edit = cl1.edit(sid, {"Map": {"x": {"Int": 5}, "y": {"Int": 0}}})
+    out = h.recv(c1, edit)
+    assert set(out) == {c1, c2}  # shared models are server-authoritative: every subscriber, incl. origin
+    for m in out[c2]:
+        cl2.recv(m)
+    assert cl2.value(sid)["Map"]["x"] == {"Int": 5}
+
+
+def test_n_by_n_routes_each_connection_its_subscribed_set():
+    h = hub()
+    a = h.share(Doc(), merge=LastWriteWins)
+    b = h.share(Doc(), merge=LastWriteWins)
+    h.subscribe("t1", a, READ)
+    h.subscribe("t1", b, READ)
+    h.subscribe("t2", b, READ)  # t2 only sees b
+    c1, c2 = ("t1", "a"), ("t2", "b")
+    h.open(c1)
+    h.open(c2)
+
+    h.set_shared(a, {"Map": {"x": {"Int": 1}, "y": {"Int": 0}}})
+    h.set_shared(b, {"Map": {"x": {"Int": 2}, "y": {"Int": 0}}})
+    out = h.flush()
+    assert len(out[c1]) == 2  # both a and b
+    assert len(out[c2]) == 1  # only b
+
+
+# --- merge strategies ----------------------------------------------------------------------------
+
+
+def test_crdt_converges_regardless_of_order():
+    base = {"Map": {"x": {"Int": 0}}}
+    # two writes to the same key from the same base revision, different origins
+    pa = {"rev": 1, "ops": [{"Set": {"path": [{"Key": "x"}], "value": {"Int": 1}}}]}
+    pb = {"rev": 1, "ops": [{"Set": {"path": [{"Key": "x"}], "value": {"Int": 2}}}]}
+
+    c1 = LwwMapCrdt()
+    v1 = c1.merge(c1.merge(base, pa, "A"), pb, "B")
+    c2 = LwwMapCrdt()
+    v2 = c2.merge(c2.merge(base, pb, "B"), pa, "A")
+    assert v1 == v2  # conflict-free: same converged value either way
+
+    # last-write-wins is order-dependent on the same conflict
+    lww = LastWriteWins()
+    l1 = lww.merge(lww.merge(base, pa, "A"), pb, "B")
+    l2 = lww.merge(lww.merge(base, pb, "B"), pa, "A")
+    assert l1 != l2
+
+
+def test_crdt_preserves_concurrent_edits_to_different_keys():
+    base = {"Map": {"x": {"Int": 0}, "y": {"Int": 0}}}
+    px = {"rev": 1, "ops": [{"Set": {"path": [{"Key": "x"}], "value": {"Int": 1}}}]}
+    py = {"rev": 1, "ops": [{"Set": {"path": [{"Key": "y"}], "value": {"Int": 1}}}]}
+    crdt = LwwMapCrdt()
+    merged = crdt.merge(crdt.merge(base, px, "A"), py, "B")
+    assert merged["Map"]["x"] == {"Int": 1}
+    assert merged["Map"]["y"] == {"Int": 1}  # neither write clobbered the other
+
+
+# --- real Starlette WebSockets -------------------------------------------------------------------
+
+
+def test_starlette_two_tenants_share_over_mixed_codecs():
+    from starlette.applications import Starlette
+    from starlette.routing import WebSocketRoute
+    from starlette.testclient import TestClient
+
+    h = Hub(key=lambda ws: ws.path_params["tenant"])
+    sid = h.share(Doc())
+    h.subscribe("alice", sid, WRITE)
+    h.subscribe("bob", sid, WRITE)
+    app = Starlette(routes=[WebSocketRoute("/ws/{tenant}", h.endpoint())])
+
+    with TestClient(app) as tc, tc.websocket_connect("/ws/alice?codec=json") as wa, tc.websocket_connect("/ws/bob?codec=msgpack") as wb:
+        ca = Client()
+        cb = Client(codec="msgpack")
+        ca.recv(wa.receive_text())  # alice: JSON snapshot
+        cb.recv(wb.receive_bytes())  # bob: msgpack snapshot
+
+        # alice writes the shared model; bob (a different tenant, different codec) receives it
+        edit = ca.edit(sid, {"Map": {"x": {"Int": 42}, "y": {"Int": 0}}})
+        assert isinstance(edit, str)
+        wa.send_text(edit)
+        cb.recv(wb.receive_bytes())
+        assert cb.value(sid)["Map"]["x"] == {"Int": 42}


### PR DESCRIPTION
One process can now serve **many tenants** and **share data structures** between them.

## What

- **`Hub(key=...)`** maps each connection to a **tenant** (via an app-supplied `key(conn)`). A tenant's private models live in their own isolated `Session`, so tenants never see each other's data.
- **Shared data structures**: `hub.share(model, merge=...)` registers a model whose authoritative state lives in the hub; tenants `hub.subscribe(tenant, sid, READ|WRITE)`. The sharing cardinality falls out of the subscription set:
  - **1-N** — one model, many `READ` subscribers (broadcast / fan-out).
  - **N-1 / N-N** — many `WRITE` subscribers on one/many shared models (collaborative).
- Shared models are **server-authoritative**: a writer sends its edit and receives the reconciled patch back; every subscriber stays in sync. `hub.set_shared(sid, value)` is the host-side write path.

## Merge seam (CRDT)

Concurrent writes to a shared model reconcile through a pluggable **`MergeStrategy`** (chosen per shared model):

- **`LastWriteWins`** (default) — apply writes in arrival order (today's `Store` semantics).
- **`LwwMapCrdt`** — conflict-free per-top-level-key LWW-register: concurrent edits to *different* fields both survive, and same-field conflicts converge to the same value **regardless of arrival order**.

Apps inject their own by implementing `merge(current, patch, origin) -> value` and passing the class to `share(merge=...)`.

## How it fits

The `Hub` mirrors `Server`'s shape — synchronous, transport-agnostic methods returning per-connection-encoded messages — so it's unit-testable without a network. `Hub.endpoint()` is the Starlette adapter and reuses the per-connection **codec negotiation** from #124; `autoflush` accepts a `Server` or `Hub` (a `Broadcaster` Protocol). Shared wire ids are namespaced (`SHARED_ID_BASE = 1<<40`) above per-`Session` ids so they never collide. **Pure Python over the Rust core — no Rust/binding changes, no rebuild.**

## Tests

`test_hub.py`: tenant isolation, private-edit relay scoped to a tenant, 1-N read fan-out, READ-only write rejection, N-1 write relay, N-N routing (each connection gets exactly its subscribed set), CRDT convergence vs. order-dependent LWW (and different-field preservation), and a real Starlette case with two tenants on **different codecs** (json + msgpack) sharing a model.

All green: **46 Python tests**, ruff / ty / docs build clean. Docs add `multitenancy.md` + an API section.

## Notes / deferred

- Access mode is whole-model (`READ`/`WRITE`); field-level visibility/authorization is Phase 4.4.
- A single-process hub linearizes writes, so the reference CRDT's visible value is order-independent, field-granular resolution; cross-hub / offline-reconnect convergence (e.g. an external automerge/yrs backend) and backpressure/coalescing remain Phase 4.3+/6.2.