### PR TITLE
Let apps register custom wire codecs

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -82,6 +82,12 @@ hosting.
 
 .. autofunction:: transports.msgpack_to_json
 
+.. autofunction:: transports.register_codec
+
+.. autofunction:: transports.unregister_codec
+
+.. autofunction:: transports.registered_codecs
+
 .. autoclass:: transports.Store
    :members:
    :undoc-members:

--- a/docs/src/codecs.md
+++ b/docs/src/codecs.md
@@ -51,3 +51,39 @@ The server encodes every outbound message in *that* connection's codec and decod
 type, so a MessagePack client's edit is transparently relayed to a JSON client and vice versa — see
 [Connections](connections.md). Whole protocol messages (not just model values) are converted with
 `json_to_msgpack` / `msgpack_to_json` (`jsonToMsgpack` / `msgpackToJson` in JavaScript).
+
+## Registering your own codec
+
+Beyond the built-ins, you can register a codec under any content type. A codec is just a pair of
+functions over a JSON-able object — a protocol message or a model `Value`:
+
+```python
+import transports
+
+transports.register_codec(
+    "application/protobuf",
+    encode=lambda obj: my_proto_encode(obj),   # object -> bytes (or str)
+    decode=lambda data: my_proto_decode(data),  # bytes (or str) -> object
+)
+```
+
+Once registered, the content type works anywhere a codec name is accepted — `Client(codec=...)`, a
+`?codec=` query param, and {py:func}`~transports.encode_as` / {py:func}`~transports.decode_as`. A
+codec returning `bytes` travels as a binary frame; returning `str` travels as a text frame. The
+built-in `json` / `msgpack` codecs cannot be overridden.
+
+Register the matching implementation in every binding that participates. JavaScript has its own
+`registerCodec`:
+
+```javascript
+import { registerCodec, Client } from "transports";
+
+registerCodec("application/protobuf", encode, decode);
+new Client("application/protobuf").connect("ws://localhost:8000/ws");
+```
+
+```{note}
+JSON and MessagePack are *self-describing*, so they encode the dynamic `Value` with no schema.
+Schema-driven formats such as Protobuf or FlatBuffers need a descriptor per model — your `encode` /
+`decode` are where that mapping lives.
+```

--- a/js/src/ts/client.ts
+++ b/js/src/ts/client.ts
@@ -1,3 +1,4 @@
+import { codecFor } from "./codecs";
 import { apply, msgpackToJson } from "./index";
 
 type SnapshotMsg = {
@@ -25,10 +26,18 @@ export class Client {
 
   constructor(private codec: string = "json") {}
 
-  /** Apply an inbound snapshot or patch frame (string JSON or binary msgpack) to the mirror. */
+  /** Apply an inbound snapshot or patch frame to the mirror.
+   *
+   * Decodes by the client's codec: a registered custom codec, else built-in JSON (text) / msgpack
+   * (binary).
+   */
   recv(data: string | Uint8Array): void {
-    const text = typeof data === "string" ? data : msgpackToJson(data);
-    const msg = JSON.parse(text) as SnapshotMsg | PatchMsg;
+    const custom = codecFor(this.codec);
+    const msg = (
+      custom
+        ? custom.decode(data)
+        : JSON.parse(typeof data === "string" ? data : msgpackToJson(data))
+    ) as SnapshotMsg | PatchMsg;
     if (msg.t === "snapshot") {
       this.values.set(msg.id, msg.value);
       this.revs.set(msg.id, msg.rev);

--- a/js/src/ts/codecs.ts
+++ b/js/src/ts/codecs.ts
@@ -1,0 +1,48 @@
+/** Custom wire codec registry (the JS analog of `transports.register_codec` in Python).
+ *
+ * A codec turns a JSON-able object (a protocol message, or a model `Value`) into a wire frame
+ * (`string` or `Uint8Array`) and back. Register a matching implementation here for any content type
+ * you also register on the server, then use it via `new Client(contentType)` / `?codec=`.
+ */
+
+export type CodecEncode = (obj: unknown) => string | Uint8Array;
+export type CodecDecode = (data: string | Uint8Array) => unknown;
+
+const BUILTIN = new Set([
+  "",
+  "json",
+  "application/json",
+  "msgpack",
+  "application/msgpack",
+  "x-msgpack",
+  "application/x-msgpack",
+]);
+
+const registry = new Map<
+  string,
+  { encode: CodecEncode; decode: CodecDecode }
+>();
+
+/** Register a custom codec under `contentType`. The built-in json/msgpack codecs cannot be overridden. */
+export function registerCodec(
+  contentType: string,
+  encode: CodecEncode,
+  decode: CodecDecode,
+): void {
+  if (BUILTIN.has(contentType)) {
+    throw new Error(`cannot override built-in codec: ${contentType}`);
+  }
+  registry.set(contentType, { encode, decode });
+}
+
+/** Remove a previously registered custom codec. */
+export function unregisterCodec(contentType: string): void {
+  registry.delete(contentType);
+}
+
+/** The currently registered custom codec for `contentType`, if any. */
+export function codecFor(
+  contentType: string,
+): { encode: CodecEncode; decode: CodecDecode } | undefined {
+  return registry.get(contentType);
+}

--- a/js/src/ts/index.ts
+++ b/js/src/ts/index.ts
@@ -43,3 +43,7 @@ export type { Value } from "./bridge";
 
 // WebSocket client that mirrors a remote Session.
 export { Client } from "./client";
+
+// Custom wire codec registry.
+export { registerCodec, unregisterCodec, codecFor } from "./codecs";
+export type { CodecEncode, CodecDecode } from "./codecs";

--- a/js/tests/import.test.js
+++ b/js/tests/import.test.js
@@ -8,6 +8,8 @@ import {
   decodeAs,
   jsonToMsgpack,
   msgpackToJson,
+  registerCodec,
+  unregisterCodec,
   Client,
 } from "../src/ts/index";
 import { initSync } from "../dist/pkg/transports";
@@ -77,6 +79,36 @@ test("Client mirrors a binary (msgpack) snapshot then patch", async () => {
     ),
   );
   expect(c.value(1)).toEqual({ Map: { on: { Bool: true } } });
+});
+
+test("a registered custom codec drives a Client", async () => {
+  // toy custom *binary* codec: a 1-byte marker + utf-8 JSON
+  const enc = new TextEncoder();
+  const dec = new TextDecoder();
+  registerCodec(
+    "application/x-test",
+    (obj) => enc.encode("X" + JSON.stringify(obj)),
+    (data) =>
+      JSON.parse((typeof data === "string" ? data : dec.decode(data)).slice(1)),
+  );
+  try {
+    const frame = enc.encode(
+      "X" +
+        JSON.stringify({
+          t: "snapshot",
+          id: 1,
+          type: "Device",
+          rev: 0,
+          value: { Map: { on: { Bool: true } } },
+        }),
+    );
+    const c = new Client("application/x-test");
+    c.recv(frame); // decoded via the registered custom codec
+    expect(c.value(1)).toEqual({ Map: { on: { Bool: true } } });
+    expect(() => registerCodec("application/json", enc, dec)).toThrow();
+  } finally {
+    unregisterCodec("application/x-test");
+  }
 });
 
 test("Client mirrors a snapshot then a patch", async () => {

--- a/transports/__init__.py
+++ b/transports/__init__.py
@@ -2,16 +2,15 @@ from . import protocol
 from ._bridge import from_value, schema_of, schema_to_ts, to_value
 from .client import Client
 from .hub import READ, WRITE, Hub, LastWriteWins, LwwMapCrdt, MergeStrategy
+from .protocol import decode_as, encode_as, register_codec, registered_codecs, unregister_codec  # registry-aware wrappers
 from .server import Server, autoflush, starlette_endpoint
 from .session import Session
 from .transports import (  # compiled Rust extension (rust/python)
     Store,
     apply,
     decode,
-    decode_as,
     diff,
     encode,
-    encode_as,
     json_to_msgpack,
     msgpack_to_json,
 )
@@ -30,6 +29,10 @@ __all__ = [
     "encode_as",
     "json_to_msgpack",
     "msgpack_to_json",
+    # custom wire codecs
+    "register_codec",
+    "unregister_codec",
+    "registered_codecs",
     # model bridge + reactive session (high-level)
     "Session",
     "to_value",

--- a/transports/client.py
+++ b/transports/client.py
@@ -30,7 +30,7 @@ class Client:
 
     def recv(self, data: Union[str, bytes]) -> None:
         """Apply an inbound snapshot or patch message (text or binary frame) to the local mirror."""
-        msg = protocol.decode(data)
+        msg = protocol.decode(data, self._codec)
         mid = msg["id"]
         if msg["t"] == "snapshot":
             self._values[mid] = msg["value"]

--- a/transports/hub.py
+++ b/transports/hub.py
@@ -194,7 +194,7 @@ class Hub:
         *other* connections. A patch to a shared model (from a `WRITE` subscriber) is merged into the
         authoritative value and the resulting patch is broadcast to every subscriber connection.
         """
-        msg = protocol.decode(data)
+        msg = protocol.decode(data, self._codecs.get(conn))
         if msg.get("t") != "patch":
             return {}
         wire_id = msg["id"]

--- a/transports/protocol.py
+++ b/transports/protocol.py
@@ -11,22 +11,62 @@ Two message kinds:
 """
 
 import json
-from typing import Any, Union
+from typing import Any, Callable, Dict, Tuple, Union
 
-from .transports import json_to_msgpack as _json_to_msgpack, msgpack_to_json as _msgpack_to_json
+from .transports import (
+    decode_as as _core_decode_as,
+    encode_as as _core_encode_as,
+    json_to_msgpack as _json_to_msgpack,
+    msgpack_to_json as _msgpack_to_json,
+)
 
 #: Canonical codec names. A connection negotiates one of these (e.g. via a ``?codec=`` query param);
 #: JSON travels as text frames, MessagePack as binary frames.
 JSON = "json"
 MSGPACK = "msgpack"
 
+_BUILTIN = {"", "json", "application/json", "msgpack", "application/msgpack", "x-msgpack", "application/x-msgpack"}
+
+#: Registered custom codecs: ``content_type -> (encode, decode)``. ``encode`` maps a JSON-able object
+#: (a protocol message, or a model ``Value``) to wire bytes/str; ``decode`` is its inverse.
+_CODECS: Dict[str, Tuple[Callable[[Any], Union[str, bytes]], Callable[[Union[str, bytes]], Any]]] = {}
+
+Codec = Tuple[Callable[[Any], Union[str, bytes]], Callable[[Union[str, bytes]], Any]]
+
+
+def register_codec(content_type: str, encode: Callable[[Any], Union[str, bytes]], decode: Callable[[Union[str, bytes]], Any]) -> None:
+    """Register a custom wire codec under ``content_type``.
+
+    ``encode`` turns a JSON-able object (a protocol message or a model ``Value``) into wire bytes (or
+    a str); ``decode`` is its inverse. Once registered, ``content_type`` works anywhere a codec name
+    is accepted — ``Client(codec=content_type)``, a ``?codec=`` query param, or ``encode_as`` /
+    ``decode_as``. Register a matching implementation in every binding that needs it (the JS binding
+    has its own ``registerCodec``). The built-in ``json`` / ``msgpack`` codecs cannot be overridden.
+    """
+    if content_type in _BUILTIN:
+        raise ValueError(f"cannot override built-in codec: {content_type}")
+    _CODECS[content_type] = (encode, decode)
+
+
+def unregister_codec(content_type: str) -> None:
+    """Remove a previously registered custom codec."""
+    _CODECS.pop(content_type, None)
+
+
+def registered_codecs() -> Tuple[str, ...]:
+    """The content types of the currently registered custom codecs."""
+    return tuple(_CODECS)
+
 
 def normalize_codec(name: Union[str, None]) -> str:
-    """Map a codec name or content-type to a canonical :data:`JSON` / :data:`MSGPACK`."""
+    """Map a codec name or content-type to a canonical name (:data:`JSON`, :data:`MSGPACK`, or a
+    registered custom content type)."""
     if name in (None, "", "json", "application/json"):
         return JSON
     if name in ("msgpack", "application/msgpack", "x-msgpack", "application/x-msgpack"):
         return MSGPACK
+    if name in _CODECS:
+        return name  # a registered content type is its own canonical name
     raise ValueError(f"unknown codec: {name}")
 
 
@@ -41,19 +81,48 @@ def patch_msg(model_id: int, patch: dict) -> str:
 def encode(msg_json: str, codec: str = JSON) -> Union[str, bytes]:
     """Encode a JSON message string into the wire form for ``codec``.
 
-    Returns the string unchanged for JSON, or MessagePack ``bytes`` for the msgpack codec — so the
-    caller sends a text frame or a binary frame accordingly.
+    Returns the string unchanged for JSON, MessagePack ``bytes`` for the msgpack codec, or whatever a
+    registered custom codec produces — so the caller sends a text or binary frame accordingly.
     """
-    if normalize_codec(codec) == MSGPACK:
+    c = normalize_codec(codec)
+    if c in _CODECS:
+        return _CODECS[c][0](json.loads(msg_json))
+    if c == MSGPACK:
         return _json_to_msgpack(msg_json)
     return msg_json
 
 
-def decode(data: Union[str, bytes]) -> dict:
-    """Parse an inbound frame to a message dict, dispatching on frame type (str=JSON, bytes=msgpack)."""
+def decode(data: Union[str, bytes], codec: Union[str, None] = None) -> dict:
+    """Parse an inbound frame to a message dict.
+
+    Pass the connection's ``codec`` to select the decoder (required for custom codecs). With no
+    ``codec`` the built-ins are inferred from the frame type (str=JSON, bytes=msgpack).
+    """
+    if codec is not None:
+        c = normalize_codec(codec)
+        if c in _CODECS:
+            return _CODECS[c][1](data)
+        if c == JSON:
+            return json.loads(data)
     if isinstance(data, (bytes, bytearray)):
         return json.loads(_msgpack_to_json(bytes(data)))
     return json.loads(data)
+
+
+def encode_as(value_json: str, content_type: str) -> bytes:
+    """Encode a model ``Value`` (JSON string) to bytes with the named codec (built-in or registered)."""
+    if content_type in _CODECS:
+        out = _CODECS[content_type][0](json.loads(value_json))
+        return out.encode() if isinstance(out, str) else out
+    return _core_encode_as(value_json, content_type)
+
+
+def decode_as(data: Union[str, bytes], content_type: str) -> str:
+    """Decode bytes back to a model ``Value`` (JSON string) with the named codec (built-in or registered)."""
+    if content_type in _CODECS:
+        return json.dumps(_CODECS[content_type][1](data))
+    raw = bytes(data) if isinstance(data, (bytes, bytearray)) else data.encode()
+    return _core_decode_as(raw, content_type)
 
 
 def parse(text: str) -> dict:

--- a/transports/server.py
+++ b/transports/server.py
@@ -58,7 +58,7 @@ class Server:
         A client patch is applied to the hosted model's value and relayed to the *other* connections,
         so the server acts as a hub. Each relay is encoded in the target connection's codec.
         """
-        msg = protocol.decode(data)
+        msg = protocol.decode(data, self._codecs.get(conn))
         if msg.get("t") == "patch":
             self._session.apply_patch(msg["id"], msg["patch"])
             relay = protocol.patch_msg(msg["id"], msg["patch"])

--- a/transports/tests/test_codec.py
+++ b/transports/tests/test_codec.py
@@ -1,8 +1,22 @@
 import json
 
 import pytest
+from pydantic import BaseModel
 
-from transports import decode_as, encode, encode_as, json_to_msgpack, msgpack_to_json, protocol
+from transports import (
+    Client,
+    Server,
+    Session,
+    decode_as,
+    encode,
+    encode_as,
+    json_to_msgpack,
+    msgpack_to_json,
+    protocol,
+    register_codec,
+    registered_codecs,
+    unregister_codec,
+)
 
 MODEL = json.dumps({"Map": {"name": {"Str": "lamp"}, "on": {"Bool": True}, "count": {"Int": 123456}}})
 
@@ -54,3 +68,76 @@ def test_normalize_codec_aliases():
     assert protocol.normalize_codec(None) == protocol.JSON
     with pytest.raises(ValueError):
         protocol.normalize_codec("application/protobuf")
+
+
+# --- custom codec registration -------------------------------------------------------------------
+
+CUSTOM = "application/x-test"
+
+
+def _enc(obj):  # toy custom *binary* codec: a 1-byte marker + utf-8 JSON
+    return b"X" + json.dumps(obj).encode()
+
+
+def _dec(data):
+    return json.loads(bytes(data)[1:])
+
+
+class _Device(BaseModel):
+    name: str
+    on: bool = False
+
+
+@pytest.fixture
+def custom_codec():
+    register_codec(CUSTOM, _enc, _dec)
+    yield CUSTOM
+    unregister_codec(CUSTOM)
+
+
+def test_register_and_normalize(custom_codec):
+    assert CUSTOM in registered_codecs()
+    assert protocol.normalize_codec(CUSTOM) == CUSTOM
+
+
+def test_cannot_override_builtin():
+    with pytest.raises(ValueError):
+        register_codec("application/json", _enc, _dec)
+
+
+def test_unregister_makes_codec_unknown():
+    register_codec(CUSTOM, _enc, _dec)
+    unregister_codec(CUSTOM)
+    assert CUSTOM not in registered_codecs()
+    with pytest.raises(ValueError):
+        protocol.normalize_codec(CUSTOM)
+
+
+def test_custom_codec_protocol_round_trip(custom_codec):
+    wire = protocol.encode(MSG, custom_codec)
+    assert isinstance(wire, bytes) and wire[:1] == b"X"
+    assert protocol.decode(wire, custom_codec) == json.loads(MSG)
+
+
+def test_custom_codec_via_encode_as(custom_codec):
+    blob = encode_as(MODEL, custom_codec)
+    assert isinstance(blob, bytes)
+    assert json.loads(decode_as(blob, custom_codec)) == json.loads(MODEL)
+
+
+def test_custom_codec_end_to_end_over_server(custom_codec):
+    session = Session()
+    server = Server(session)
+    d = _Device(name="lamp")
+    mid = session.host(d)
+    client = Client(codec=custom_codec)
+
+    for m in server.open("c", codec=custom_codec):
+        assert isinstance(m, bytes)  # our codec frames as binary
+        client.recv(m)
+    assert client.model(mid, _Device) == d
+
+    d.on = True
+    for m in server.flush()["c"]:
+        client.recv(m)
+    assert client.model(mid, _Device).on is True


### PR DESCRIPTION
Answers "can I register my own codec (e.g. serialize my type to Protobuf)?" — **yes, now you can.**

> Stacked on #125 (touches `hub.py`); GitHub will retarget this to `main` once #125 merges.

## What

Codecs were a closed Rust `match` (json/msgpack only). This adds a **binding-level registry**:

```python
transports.register_codec(
    "application/protobuf",
    encode=lambda obj: my_proto_encode(obj),   # JSON-able object -> bytes (or str)
    decode=lambda data: my_proto_decode(data),  # bytes (or str) -> object
)
```

Once registered, the content type works **everywhere a codec name is accepted**: `Client(codec=...)`, a `?codec=` query param, and `encode_as` / `decode_as`. A codec returning `bytes` rides a binary frame; returning `str` a text frame. Built-in json/msgpack can't be overridden.

## How

- `protocol.py` holds the registry; `normalize_codec` / `encode` / `decode` / `encode_as` / `decode_as` consult it. `encode`/`decode` operate on the protocol message; `encode_as`/`decode_as` on a model `Value` — both are JSON-able objects, so one registered codec serves both.
- `Server` / `Hub` / `Client` now pass their connection's codec into `decode` — a custom **binary** codec can't be inferred from the frame type the way msgpack could. `__init__` re-exports the registry-aware `encode_as`/`decode_as` (shadowing the raw core fns).
- **JS mirror:** `js/src/ts/codecs.ts` (`registerCodec` / `unregisterCodec` / `codecFor`) + a codec-aware `Client`. Each binding registers its own implementation, same as the core ships json/msgpack in both.
- **Pure Python/TS — no Rust or binding changes, no rebuild.**

## Note on Protobuf specifically

JSON and MessagePack are *self-describing*, so they encode the dynamic `Value` with no schema. Schema-driven formats (Protobuf/FlatBuffers) need a descriptor per model — that mapping lives in *your* `encode`/`decode`. A built-in, schema-derived Protobuf codec in the core remains roadmap 2.4.

## Tests

Python: register/normalize, builtin-override rejection, unregister, `protocol.encode/decode` + `encode_as`/`decode_as` round-trips, and an end-to-end custom-codec `Server` ↔ `Client` mirror. JS: a `registerCodec`-driven `Client` decoding a custom binary frame + override rejection.

All green: **52 Python tests**, **8 Playwright tests**, ruff / ty / prettier / docs build clean. Docs add a "Registering your own codec" section in `codecs.md` + API entries.