### PR TITLE
SSE + Jupyter comm adapters; server-authoritative live receive

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -39,6 +39,12 @@ The high-level reactive session, the model bridge, the connection adapters, and 
 .. autofunction:: transports.starlette_endpoint
 
 .. autofunction:: transports.autoflush
+
+.. autofunction:: transports.sse_endpoint
+
+.. autofunction:: transports.serve_comm
+
+.. autofunction:: transports.pump_comms
 ```
 
 ## Multi-tenancy & sharing

--- a/docs/src/connections.md
+++ b/docs/src/connections.md
@@ -47,7 +47,15 @@ app = Starlette(
 ```
 
 On connect, a client receives a snapshot of every hosted model, then a stream of patches. A patch a
-client sends back is applied and relayed to the *other* clients, so the server acts as a hub.
+client sends back is applied and broadcast, so the server acts as a hub.
+
+### Server-authoritative edits
+
+Models are **server-authoritative**: a client's `edit(id, value)` is a *proposal*. The server applies
+it, owns the revision (`rev`), and echoes the authoritative patch to **every** connection — including
+the one that sent it. A client's local mirror therefore updates when that echo arrives, not
+optimistically, so all mirrors and the server's own hosted object stay in lock-step without `rev`
+drift. (For multi-writer convergence on shared models, see [Multi-tenancy](multitenancy.md).)
 
 ### Choosing a codec
 
@@ -84,6 +92,55 @@ ws.addEventListener("message", (e) => {
   render(client.value(1)); // your render function
 });
 ```
+
+## Server-Sent Events (receive-only)
+
+For receive-mostly UIs (dashboards), a server can push over **SSE** — a one-way server→client stream.
+{py:func}`~transports.sse_endpoint` builds a Starlette route; run {py:func}`~transports.autoflush` to
+stream changes. Clients receive snapshots and patches but do not send edits back (use WebSocket for
+that).
+
+```bash
+pip install "transports[sse]"
+```
+
+```python
+from starlette.routing import Route
+
+app = Starlette(
+    routes=[Route("/sse", transports.sse_endpoint(server))],
+    on_startup=[lambda: asyncio.create_task(transports.autoflush(server))],
+)
+```
+
+```python
+client = transports.Client()
+await client.connect_sse("http://localhost:8000/sse")   # mirrors until the stream closes
+```
+
+In the browser, the JavaScript `Client` mirrors a stream with `connectSSE(url)` (native
+`EventSource`).
+
+## Jupyter (comm)
+
+Inside a kernel, a model syncs to the frontend over a **Jupyter comm** — the same channel ipywidgets
+use. {py:func}`~transports.serve_comm` wires a comm (the connection handle) to a `Server`/`Hub`;
+{py:func}`~transports.pump_comms` pushes host-side changes after you mutate models.
+
+```bash
+pip install "transports[jupyter]"
+```
+
+```python
+from comm import create_comm
+
+comm = create_comm(target_name="transports")
+transports.serve_comm(server, comm)   # send snapshots, relay inbound edits
+# ... mutate hosted models ...
+transports.pump_comms(server)          # push patches to the frontend
+```
+
+The comm carries the same messages, so the browser `Client` mirrors it unchanged.
 
 ## Runnable example
 

--- a/js/src/ts/client.ts
+++ b/js/src/ts/client.ts
@@ -1,5 +1,5 @@
 import { codecFor } from "./codecs";
-import { apply, msgpackToJson } from "./index";
+import { apply, diff, jsonToMsgpack, msgpackToJson } from "./index";
 
 type SnapshotMsg = {
   t: "snapshot";
@@ -60,6 +60,22 @@ export class Client {
     return [...this.values.keys()];
   }
 
+  /** Propose an edit to a mirrored model; returns the patch frame to send (encoded in this codec).
+   *
+   * Server-authoritative: the local mirror updates when the server echoes the authoritative patch
+   * back via `recv`, not optimistically.
+   */
+  edit(id: number, value: unknown): string | Uint8Array {
+    const patch = JSON.parse(
+      diff(JSON.stringify(this.values.get(id)), JSON.stringify(value)),
+    );
+    const msg = { t: "patch", id, patch };
+    const custom = codecFor(this.codec);
+    if (custom) return custom.encode(msg);
+    const s = JSON.stringify(msg);
+    return this.codec === "msgpack" ? jsonToMsgpack(s) : s;
+  }
+
   /** Connect to a transports server and mirror it. Returns the `WebSocket`. */
   connect(url: string): WebSocket {
     const sep = url.includes("?") ? "&" : "?";
@@ -72,5 +88,14 @@ export class Client {
       );
     });
     return ws;
+  }
+
+  /** Mirror a server over Server-Sent Events (receive-only, JSON). Returns the `EventSource`. */
+  connectSSE(url: string): EventSource {
+    const es = new EventSource(url);
+    es.addEventListener("message", (e) =>
+      this.recv((e as MessageEvent).data as string),
+    );
+    return es;
   }
 }

--- a/js/tests/import.test.js
+++ b/js/tests/import.test.js
@@ -134,3 +134,24 @@ test("Client mirrors a snapshot then a patch", async () => {
   );
   expect(c.value(1)).toEqual({ Map: { on: { Bool: true } } });
 });
+
+test("Client.edit is send-only; mirror updates on the server echo", async () => {
+  const c = new Client();
+  c.recv(
+    JSON.stringify({
+      t: "snapshot",
+      id: 1,
+      type: "Device",
+      rev: 0,
+      value: { Map: { on: { Bool: false } } },
+    }),
+  );
+  const frame = c.edit(1, { Map: { on: { Bool: true } } });
+  const msg = JSON.parse(frame);
+  expect(msg.t).toBe("patch");
+  // server-authoritative: edit does not mutate the local mirror...
+  expect(c.value(1)).toEqual({ Map: { on: { Bool: false } } });
+  // ...the mirror updates when the server echoes the authoritative patch back
+  c.recv(JSON.stringify({ t: "patch", id: 1, patch: msg.patch }));
+  expect(c.value(1)).toEqual({ Map: { on: { Bool: true } } });
+});

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,21 +44,35 @@ connections = [
     "starlette",
     "websockets",
 ]
+# Server-Sent Events adapter (Starlette server stream, httpx client)
+sse = [
+    "sse-starlette",
+    "httpx-sse",
+    "httpx",
+]
+# Jupyter comm adapter (kernel-side comm channel)
+jupyter = [
+    "comm",
+]
 develop = [
     "build",
     "bump-my-version",
     "check-dist",
     "cibuildwheel",
     "codespell",
+    "comm",
     "hatch-js",
     "hatch-rs",
     "hatchling",
     "httpx",
+    "httpx-sse",
+    "ipykernel",
     "mdformat",
     "mdformat-tables>=1",
     "pytest",
     "pytest-cov",
     "ruff",
+    "sse-starlette",
     "starlette",
     "twine",
     "websockets",

--- a/transports/__init__.py
+++ b/transports/__init__.py
@@ -1,10 +1,12 @@
 from . import protocol
 from ._bridge import from_value, schema_of, schema_to_ts, to_value
 from .client import Client
+from .comm import pump_comms, serve_comm
 from .hub import READ, WRITE, Hub, LastWriteWins, LwwMapCrdt, MergeStrategy
 from .protocol import decode_as, encode_as, register_codec, registered_codecs, unregister_codec  # registry-aware wrappers
 from .server import Server, autoflush, starlette_endpoint
 from .session import Session
+from .sse import sse_endpoint
 from .transports import (  # compiled Rust extension (rust/python)
     Store,
     apply,
@@ -39,11 +41,14 @@ __all__ = [
     "from_value",
     "schema_of",
     "schema_to_ts",
-    # connections (WebSocket)
+    # connections (WebSocket / SSE / Jupyter comm)
     "Server",
     "Client",
     "starlette_endpoint",
     "autoflush",
+    "sse_endpoint",
+    "serve_comm",
+    "pump_comms",
     "protocol",
     # multi-tenancy + sharing
     "Hub",

--- a/transports/client.py
+++ b/transports/client.py
@@ -52,11 +52,13 @@ class Client:
         return list(self._values)
 
     def edit(self, mid: int, new_value: Any) -> Union[str, bytes]:
-        """Locally edit a mirrored model and return the patch frame to send (encoded in this codec)."""
+        """Propose an edit to a mirrored model; returns the patch frame to send (encoded in this codec).
+
+        Models are server-authoritative: the edit is a proposal, and the local mirror updates only
+        when the server echoes the authoritative patch back (via `recv`), not optimistically. This
+        keeps `rev` owned by the server and avoids client/server `rev` divergence.
+        """
         patch = json.loads(_diff(json.dumps(self._values[mid]), json.dumps(new_value)))
-        patch["rev"] = self._rev[mid] + 1
-        self._values[mid] = new_value
-        self._rev[mid] = patch["rev"]
         return protocol.encode(protocol.patch_msg(mid, patch), self._codec)
 
     async def connect(self, url: str) -> None:
@@ -70,3 +72,16 @@ class Client:
         async with websockets.connect(f"{url}{sep}codec={self._codec}") as ws:
             async for frame in ws:
                 self.recv(frame)
+
+    async def connect_sse(self, url: str) -> None:
+        """Mirror a transports server over Server-Sent Events (receive-only) until the stream closes.
+
+        SSE is a one-way server→client channel, so this only receives snapshots and patches; use
+        `connect()` (WebSocket) when the client also needs to send edits.
+        """
+        import httpx
+        from httpx_sse import aconnect_sse
+
+        async with httpx.AsyncClient() as http, aconnect_sse(http, "GET", url) as source:
+            async for event in source.aiter_sse():
+                self.recv(event.data)

--- a/transports/comm.py
+++ b/transports/comm.py
@@ -1,0 +1,59 @@
+"""Serve a `Session`/`Hub` over a Jupyter comm channel.
+
+A Jupyter **comm** is a bidirectional message channel between a kernel and a frontend (the transport
+behind ipywidgets). It carries JSON-able data natively, so transports rides it by sending the wire
+*string* as the comm's ``data`` — no extra framing, and the same `Client.recv`/`edit` work unchanged.
+The comm object itself is the connection handle.
+
+This adapter never imports `comm`/`ipykernel`: you pass in a comm (created by your widget, or
+`comm.create_comm(...)`), keeping the Jupyter dependency optional. It is therefore also testable with
+a duck-typed fake comm exposing ``send`` / ``on_msg`` / ``on_close``.
+
+```python
+import transports
+
+session = transports.Session()
+session.host(model)
+server = transports.Server(session)
+
+transports.serve_comm(server, my_comm)   # sends snapshots, wires inbound messages
+# ... mutate model(s) ...
+transports.pump_comms(server)            # push host-side changes to every comm
+```
+"""
+
+from typing import Any
+
+from . import protocol
+from .server import Broadcaster
+
+
+def serve_comm(server: Broadcaster, comm: Any, codec: str = protocol.JSON) -> Any:
+    """Wire a comm to a `Server`/`Hub`: send the opening snapshots and relay inbound messages.
+
+    The comm is registered as a connection; its messages (``msg["content"]["data"]``) are fed to
+    ``server.recv`` and any resulting messages are sent back over the relevant comms. Returns the comm
+    (the connection handle), so the caller can `pump_comms(server)` after host-side mutations.
+    """
+    for wire in server.open(comm, codec):
+        comm.send(data=wire)
+
+    def _on_msg(msg: dict) -> None:
+        for target, msgs in server.recv(comm, msg["content"]["data"]).items():
+            for m in msgs:
+                target.send(data=m)
+
+    comm.on_msg(_on_msg)
+    comm.on_close(lambda _msg: server.close(comm))
+    return comm
+
+
+def pump_comms(server: Broadcaster) -> None:
+    """Flush host-side changes and push the resulting patches to every connected comm.
+
+    Call after mutating hosted models (e.g. at the end of a cell, or from a timer). Each connection
+    handle is a comm, so the patches are delivered with `comm.send`.
+    """
+    for comm, msgs in server.flush().items():
+        for m in msgs:
+            comm.send(data=m)

--- a/transports/hub.py
+++ b/transports/hub.py
@@ -190,9 +190,10 @@ class Hub:
     def recv(self, conn: Any, data: Wire) -> Dict[Any, List[Wire]]:
         """Handle an inbound patch; returns messages to send, keyed by connection.
 
-        A patch to a private model is applied to the tenant's session and relayed to that tenant's
-        *other* connections. A patch to a shared model (from a `WRITE` subscriber) is merged into the
-        authoritative value and the resulting patch is broadcast to every subscriber connection.
+        A patch to a private model is applied as the server (the tenant's session owns `rev`) and the
+        authoritative patch is broadcast to *all* of that tenant's connections. A patch to a shared
+        model (from a `WRITE` subscriber) is merged into the authoritative value and broadcast to
+        every subscriber connection. Both paths are server-authoritative (origin included).
         """
         msg = protocol.decode(data, self._codecs.get(conn))
         if msg.get("t") != "patch":
@@ -208,9 +209,11 @@ class Hub:
         sess = self._tenants.get(key)
         if sess is None:
             return {}
-        sess.apply_patch(wire_id, msg["patch"])
-        relay = protocol.patch_msg(wire_id, msg["patch"])
-        return {c: [self._encode_for(c, relay)] for c, k in self._conn_key.items() if k == key and c is not conn}
+        authoritative = sess.submit(wire_id, msg["patch"])
+        if authoritative is None:
+            return {}
+        relay = protocol.patch_msg(wire_id, authoritative)
+        return {c: [self._encode_for(c, relay)] for c, k in self._conn_key.items() if k == key}
 
     def flush(self) -> Dict[Any, List[Wire]]:
         """Drain every tenant session and any host-side shared writes; route the patches per tenant/subscription."""

--- a/transports/server.py
+++ b/transports/server.py
@@ -21,7 +21,11 @@ Wire = Union[str, bytes]
 
 
 class Broadcaster(Protocol):
-    """The structural contract `autoflush` drives — satisfied by both `Server` and `Hub`."""
+    """The structural contract the I/O adapters drive — satisfied by both `Server` and `Hub`."""
+
+    def open(self, conn: Any, codec: str = ...) -> List[Wire]: ...
+
+    def recv(self, conn: Any, data: Wire) -> Dict[Any, List[Wire]]: ...
 
     def flush(self) -> Dict[Any, List[Wire]]: ...
 
@@ -55,14 +59,18 @@ class Server:
     def recv(self, conn: Any, data: Wire) -> Dict[Any, List[Wire]]:
         """Handle an inbound message (text or binary frame); returns messages to send, keyed by conn.
 
-        A client patch is applied to the hosted model's value and relayed to the *other* connections,
-        so the server acts as a hub. Each relay is encoded in the target connection's codec.
+        A client patch is a *proposal*: the server applies it, bumps its own authoritative `rev`, and
+        echoes the resulting patch to **every** connection (including the origin), each in that
+        connection's codec. Models are server-authoritative — a client's mirror updates when this echo
+        arrives, not optimistically.
         """
         msg = protocol.decode(data, self._codecs.get(conn))
         if msg.get("t") == "patch":
-            self._session.apply_patch(msg["id"], msg["patch"])
-            relay = protocol.patch_msg(msg["id"], msg["patch"])
-            return {c: [self._encode_for(c, relay)] for c in self._codecs if c is not conn}
+            authoritative = self._session.submit(msg["id"], msg["patch"])
+            if authoritative is None:
+                return {}
+            relay = protocol.patch_msg(msg["id"], authoritative)
+            return {c: [self._encode_for(c, relay)] for c in self._codecs}
         return {}
 
     def flush(self) -> Dict[Any, List[Wire]]:

--- a/transports/session.py
+++ b/transports/session.py
@@ -15,7 +15,7 @@ from typing import Any, Callable, Dict, List, Optional, Set, Tuple
 
 from bigbrother import watch
 
-from ._bridge import schema_of, to_value
+from ._bridge import _annotations, from_value, schema_of, to_value
 from .transports import Store as _CoreStore
 
 
@@ -25,6 +25,7 @@ class Session:
         self._models: Dict[int, Any] = {}
         self._schemas: Dict[str, dict] = {}
         self._dirty: Set[int] = set()
+        self._suppress: Set[int] = set()  # ids whose observation is suspended (during inbound apply)
         self.outbox: List[Tuple[int, dict]] = []
         self._on_patch: Optional[Callable[[int, dict], None]] = None
 
@@ -35,7 +36,8 @@ class Session:
         mid = self._store.host(type_name, json.dumps(to_value(model)))
 
         def _watcher(obj: object, method: str, ref: object, call_args: tuple, call_kwargs: dict, _mid: int = mid) -> None:
-            self._dirty.add(_mid)
+            if _mid not in self._suppress:  # ignore writes we make ourselves while applying inbound patches
+                self._dirty.add(_mid)
 
         self._models[mid] = watch(model, _watcher, deepstate=True)
         return mid
@@ -93,8 +95,47 @@ class Session:
         return self.snapshot(mid)["value"]
 
     def apply_patch(self, mid: int, patch: dict) -> bool:
-        """Apply a remote patch to a hosted/mirrored model's core value. Returns whether id was known."""
-        return self._store.apply(mid, json.dumps(patch))
+        """Apply an authoritative remote patch to a hosted/mirrored model (adopts the patch's `rev`).
+
+        Also refreshes the hosted Python object so the caller's own reference stays in sync — the
+        update is made under observation suppression so it doesn't echo back as a new patch.
+        """
+        return self._apply_authoritative(mid, patch)
+
+    def submit(self, mid: int, patch: dict) -> Optional[dict]:
+        """Apply a client-proposed patch *as the server*: the server owns `rev`.
+
+        The proposal's ops are applied to the hosted value, the server's `rev` is bumped (not the
+        client's guess), the hosted Python object is refreshed, and the authoritative patch (with the
+        server `rev`) is returned to broadcast to every connection. `None` if the id is unknown.
+        """
+        snap = self._store.snapshot(mid)
+        if snap is None:
+            return None
+        cur_rev = json.loads(snap)["rev"]
+        authoritative = {"rev": cur_rev + 1, "ops": patch.get("ops", [])}
+        self._apply_authoritative(mid, authoritative)
+        return authoritative
+
+    def _apply_authoritative(self, mid: int, patch: dict) -> bool:
+        if not self._store.apply(mid, json.dumps(patch)):
+            return False
+        self._refresh_model(mid)
+        return True
+
+    def _refresh_model(self, mid: int) -> None:
+        """Rewrite the hosted Python object from the core value, without re-triggering observation."""
+        obj = self._models.get(mid)
+        snap = self._store.snapshot(mid)
+        if obj is None or snap is None:
+            return
+        fresh = from_value(json.loads(snap)["value"], type(obj))
+        self._suppress.add(mid)
+        try:
+            for name in _annotations(type(obj)):
+                setattr(obj, name, getattr(fresh, name))
+        finally:
+            self._suppress.discard(mid)
 
     def schema(self, type_name: str) -> Optional[dict]:
         return self._schemas.get(type_name)

--- a/transports/sse.py
+++ b/transports/sse.py
@@ -1,0 +1,68 @@
+"""Serve a `Session`/`Hub` over Server-Sent Events (receive-only).
+
+SSE is a one-way server→client stream (the browser `EventSource`), well suited to receive-mostly UIs
+like dashboards. A client receives the opening snapshots and then a live stream of patches; it does
+not send edits back over SSE (use the WebSocket adapter for bidirectional sync).
+
+The adapter reuses the existing `autoflush` driver: each SSE connection is a queue-backed handle
+whose `send_text` enqueues a message, and the streaming response drains that queue. SSE is a text
+channel, so the JSON codec is used.
+
+```python
+from starlette.routing import Route
+import transports
+
+app = Starlette(
+    routes=[Route("/sse", transports.sse_endpoint(server))],
+    on_startup=[lambda: asyncio.create_task(transports.autoflush(server))],
+)
+```
+"""
+
+import asyncio
+from typing import Any
+
+from . import protocol
+from .server import Broadcaster
+
+
+class _SSEConn:
+    """A connection handle that buffers outbound messages for an SSE stream to drain."""
+
+    def __init__(self) -> None:
+        self.queue: asyncio.Queue = asyncio.Queue()
+
+    async def send_text(self, msg: str) -> None:
+        await self.queue.put(msg)
+
+    async def send_bytes(self, data: bytes) -> None:  # SSE is text; decode for the rare binary frame
+        await self.queue.put(data.decode())
+
+
+async def sse_stream(server: Broadcaster, conn: _SSEConn):
+    """Async generator of wire messages for one SSE connection: the opening snapshots, then patches.
+
+    Patches arrive on the connection's queue via `autoflush` (which calls `send_text`). Closes the
+    connection when the consumer stops iterating.
+    """
+    for wire in server.open(conn, protocol.JSON):  # snapshots first
+        await conn.queue.put(wire)
+    try:
+        while True:
+            yield await conn.queue.get()
+    finally:
+        server.close(conn)
+
+
+def sse_endpoint(server: Broadcaster):
+    """Build a Starlette endpoint that streams a `Server`/`Hub` to a client over SSE.
+
+    Wire it into an app as a normal route (``Route("/sse", sse_endpoint(server))``) and run
+    `autoflush(server)` as a background task to stream server-side model changes to connected clients.
+    """
+    from sse_starlette import EventSourceResponse
+
+    async def endpoint(request: Any):
+        return EventSourceResponse(sse_stream(server, _SSEConn()))
+
+    return endpoint

--- a/transports/tests/test_comm.py
+++ b/transports/tests/test_comm.py
@@ -1,0 +1,94 @@
+from typing import Any
+
+from pydantic import BaseModel
+
+from transports import Client, Hub, Server, Session, pump_comms, serve_comm
+
+
+class Device(BaseModel):
+    name: str
+    on: bool = False
+
+
+class FakeComm:
+    """A duck-typed Jupyter comm: records sent data, lets a test fire an inbound message."""
+
+    def __init__(self) -> None:
+        self.sent: list = []
+        self._on_msg: Any = None
+        self.closed = False
+
+    def send(self, data=None, metadata=None, buffers=None) -> None:
+        self.sent.append(data)
+
+    def on_msg(self, cb) -> None:
+        self._on_msg = cb
+
+    def on_close(self, cb) -> None:
+        self._on_close = cb
+
+    def fire(self, data) -> None:
+        self._on_msg({"content": {"data": data}})
+
+
+def test_serve_comm_sends_opening_snapshot():
+    session = Session()
+    server = Server(session)
+    d = Device(name="lamp")
+    mid = session.host(d)
+    comm = FakeComm()
+
+    serve_comm(server, comm)
+    assert len(comm.sent) == 1
+    client = Client()
+    client.recv(comm.sent[0])
+    assert client.model(mid, Device) == d
+
+
+def test_comm_inbound_edit_is_applied_and_echoed():
+    session = Session()
+    server = Server(session)
+    d = Device(name="lamp")
+    mid = session.host(d)
+    a, b = FakeComm(), FakeComm()
+    serve_comm(server, a)
+    serve_comm(server, b)
+
+    client = Client()
+    client.recv(a.sent[0])
+    a.sent.clear()
+    b.sent.clear()
+
+    a.fire(client.edit(mid, {"Map": {"name": {"Str": "lamp"}, "on": {"Bool": True}}}))
+    # server-authoritative: both comms (incl. origin) receive the echo, host object updates
+    assert len(a.sent) == 1 and len(b.sent) == 1
+    client.recv(b.sent[0])
+    assert client.model(mid, Device).on is True
+    assert d.on is True
+
+
+def test_pump_comms_delivers_host_side_changes():
+    session = Session()
+    server = Server(session)
+    d = Device(name="lamp")
+    session.host(d)
+    comm = FakeComm()
+    serve_comm(server, comm)
+    comm.sent.clear()
+
+    d.name = "desk"
+    pump_comms(server)
+    assert len(comm.sent) == 1
+
+
+def test_serve_comm_works_with_hub():
+    hub = Hub(key=lambda c: "t")
+    d = Device(name="lamp")
+    sid = hub.share(d)
+    hub.subscribe("t", sid)
+    comm = FakeComm()
+    serve_comm(hub, comm)
+    assert len(comm.sent) == 1  # the shared model's snapshot
+    client = Client()
+    client.recv(comm.sent[0])
+    assert client.model(sid, Device) == d

--- a/transports/tests/test_connection.py
+++ b/transports/tests/test_connection.py
@@ -63,11 +63,14 @@ def test_client_edit_relays_to_other_clients():
     for m in server.open("b"):
         b.recv(m)
 
-    msg = a.edit(mid, to_value(Device(name="lamp", on=True)))  # client a edits, sends to server
+    msg = a.edit(mid, to_value(Device(name="lamp", on=True)))  # client a proposes an edit
     out = server.recv("a", msg)
-    assert set(out) == {"b"}  # relayed to b, not back to a
+    assert set(out) == {"a", "b"}  # server-authoritative: echoed to everyone, incl. the origin
+    for m in out["a"]:
+        a.recv(m)
     for m in out["b"]:
         b.recv(m)
+    assert a.model(mid, Device).on is True  # origin's mirror updates on the echo, not optimistically
     assert b.model(mid, Device).on is True
 
 
@@ -78,6 +81,39 @@ def test_flush_without_connections_is_empty():
     session.host(d)
     d.on = True
     assert server.flush() == {}
+
+
+def test_inbound_edit_updates_host_object_without_echo_loop():
+    session = Session()
+    server = Server(session)
+    d = Device(name="lamp")
+    mid = session.host(d)
+    a = Client()
+    for m in server.open("a"):
+        a.recv(m)
+
+    server.recv("a", a.edit(mid, to_value(Device(name="lamp", on=True))))
+    assert d.on is True  # the server's hosted Python object reflects the edit (no staleness)
+    assert session.snapshot(mid)["rev"] == 1  # server owns the rev
+    assert session.drain() == []  # the in-place refresh did not re-trigger observation (no echo loop)
+
+
+def test_two_clients_converge_on_server_rev():
+    session = Session()
+    server = Server(session)
+    d = Device(name="lamp")
+    mid = session.host(d)
+    a, b = Client(), Client()
+    for m in server.open("a"):
+        a.recv(m)
+    for m in server.open("b"):
+        b.recv(m)
+
+    for _conn, msgs in server.recv("a", a.edit(mid, to_value(Device(name="lamp", on=True)))).items():
+        for m in msgs:
+            (a if _conn == "a" else b).recv(m)
+    assert a._rev[mid] == b._rev[mid] == 1
+    assert a.value(mid) == b.value(mid)
 
 
 # --- codec negotiation ---------------------------------------------------------------------------
@@ -141,8 +177,9 @@ def test_msgpack_client_edit_relays_to_json_client():
     edit = m.edit(mid, to_value(Device(name="lamp", on=True)))  # msgpack client edits (binary frame)
     assert isinstance(edit, bytes)
     out = server.recv("m", edit)
-    assert set(out) == {"j"}
-    for msg in out["j"]:  # relayed to the JSON client, re-encoded as text
+    assert set(out) == {"j", "m"}  # echoed to all, each in its own codec
+    assert all(isinstance(x, bytes) for x in out["m"])  # msgpack origin gets binary
+    for msg in out["j"]:  # the JSON client gets it re-encoded as text
         assert isinstance(msg, str)
         j.recv(msg)
     assert j.model(mid, Device).on is True

--- a/transports/tests/test_hub.py
+++ b/transports/tests/test_hub.py
@@ -46,7 +46,7 @@ def test_private_edit_relays_only_within_tenant():
 
     edit = '{"t":"patch","id":1,"patch":{"rev":1,"ops":[{"Set":{"path":[{"Key":"x"}],"value":{"Int":7}}}]}}'
     out = h.recv(a1, edit)
-    assert set(out) == {a2}  # relayed to the other connection in t1, not to t2
+    assert set(out) == {a1, a2}  # server-authoritative: echoed to all of t1 (incl origin), not t2
     for m in out[a2]:
         ca2.recv(m)
     assert ca2.value(1)["Map"]["x"] == {"Int": 7}

--- a/transports/tests/test_sse.py
+++ b/transports/tests/test_sse.py
@@ -1,0 +1,46 @@
+import asyncio
+
+from pydantic import BaseModel
+
+from transports import Client, Server, Session
+from transports.sse import _SSEConn, sse_stream
+
+
+class Device(BaseModel):
+    name: str
+    on: bool = False
+
+
+def test_sse_stream_yields_snapshot_then_patch():
+    """Drive the SSE stream generator directly (the `EventSourceResponse` wrapper is a thin shim).
+
+    Exercises the real `_SSEConn`, `server.open`, and the autoflush delivery path (`_send` ->
+    `send_text` -> queue) without an in-process HTTP server (httpx's ASGITransport can't stream an
+    unbounded SSE body).
+    """
+
+    async def run():
+        session = Session()
+        server = Server(session)
+        d = Device(name="lamp")
+        mid = session.host(d)
+        conn = _SSEConn()
+        stream = sse_stream(server, conn)
+        client = Client()
+
+        snap = await asyncio.wait_for(stream.__anext__(), 1)  # snapshot streams first
+        client.recv(snap)
+        assert client.model(mid, Device) == d
+
+        d.on = True  # host-side mutation -> the autoflush driver delivers via send_text
+        for c, msgs in server.flush().items():
+            for m in msgs:
+                await c.send_text(m)
+
+        patch = await asyncio.wait_for(stream.__anext__(), 1)
+        client.recv(patch)
+        assert client.model(mid, Device).on is True
+
+        await stream.aclose()
+
+    asyncio.run(run())


### PR DESCRIPTION
Adds two new connection transports over the existing transport-agnostic `Server`/`Hub`, and fixes the **live-receive** correctness gap that the Hub's collaborative shared models made pressing.

## Server-authoritative receive (the correctness foundation)

Previously a client's `edit()` optimistically mutated its local mirror and guessed a `rev`, and the server relayed that patch (with the client's `rev`) to *other* clients — so the server's own hosted Python object went **stale** after an inbound patch, and concurrent client `rev`s could collide.

Now:
- `Client.edit(id, value)` is a **proposal** — send-only, no optimistic local apply (Python + JS).
- `Session.submit` applies the proposal, bumps the **server's** own `rev`, and refreshes the hosted Python object **in place** under observation suppression (`self._suppress`) — no staleness, and no echo loop.
- `Server.recv` / `Hub.recv` (private path) echo the authoritative patch to **every** connection including the origin. Clients adopt the server `rev` on receive.

Result: mirrors and the server's hosted object stay in lock-step with no `rev` drift. (Aligns the plain `Server` with the `Hub`, which was already authoritative for shared models.)

## SSE — receive-only (3.3)

`sse_endpoint(server)` streams a `Server`/`Hub` over Server-Sent Events (Starlette `EventSourceResponse`, fed by `autoflush`); `sse_stream(server, conn)` is the testable generator. Python `Client.connect_sse` (`httpx-sse`) and a browser `Client.connectSSE` (native `EventSource`). For dashboards/read-mostly UIs; writes go via WebSocket (or HTTP POST, 3.4). Optional `transports[sse]` extra.

## Jupyter comm (3.5)

`serve_comm(server, comm)` wires a kernel-side comm (the connection handle) to a `Server`/`Hub`, carrying the wire string as comm `data` so the browser `Client` mirrors it unchanged; `pump_comms(server)` pushes host-side changes. No hard `comm` dependency — the caller supplies the comm. Optional `transports[jupyter]` extra. Unblocks daggre-in-notebook.

## Notes

- Adapter deps are **lazy-imported** so `import transports` never requires them; new extras `sse` / `jupyter` (and all test deps added to `develop`).
- The `Broadcaster` protocol now declares `open`/`recv` so both adapters type-check against `Server`|`Hub`.
- **Pure Python/TS over the core — no Rust or binding changes.**

## Tests

59 Python (live-receive: host-object refresh + no echo loop + two-client `rev` convergence; comm via a fake comm for both `Server` and `Hub`; SSE stream generator) + 9 Playwright (send-only `edit`). The in-process SSE HTTP harness can't stream an unbounded body (httpx `ASGITransport` buffers), so SSE is tested at the stream-generator level; `connect_sse`/`connectSSE` are the real-network entry points. ruff / ty / prettier / docs build all clean; core `cargo test` unchanged (29).

Updates `connections.md` (SSE + comm + server-authoritative note) and the API reference.