### PR TITLE
Remove decorative divider comments (slop markers)

### DIFF
--- a/rust/src/bridge.rs
+++ b/rust/src/bridge.rs
@@ -111,7 +111,6 @@ impl JsonStore {
     }
 }
 
-/*********************************/
 #[cfg(test)]
 mod bridge_tests {
     use super::*;

--- a/rust/src/codec.rs
+++ b/rust/src/codec.rs
@@ -89,7 +89,6 @@ pub fn codec_for(content_type: &str) -> Option<Box<dyn Codec>> {
     }
 }
 
-/*********************************/
 #[cfg(test)]
 mod codec_tests {
     use super::*;

--- a/rust/src/diff.rs
+++ b/rust/src/diff.rs
@@ -182,7 +182,6 @@ fn apply_op(root: &mut Value, op: &Op) {
     }
 }
 
-/*********************************/
 #[cfg(test)]
 mod diff_tests {
     use super::*;
@@ -260,8 +259,6 @@ mod diff_tests {
         let v = Value::map([("a", Value::from(1i64)), ("b", Value::from(vec!["x"]))]);
         assert!(diff(&v, &v).is_empty());
     }
-
-    // ---- deterministic property-based fuzz ----
 
     struct Lcg(u64);
     impl Lcg {

--- a/rust/src/frame.rs
+++ b/rust/src/frame.rs
@@ -120,7 +120,6 @@ fn read_u32(bytes: &[u8], at: usize) -> Result<u32, FrameError> {
     Ok(u32::from_be_bytes([slice[0], slice[1], slice[2], slice[3]]))
 }
 
-/*********************************/
 #[cfg(test)]
 mod frame_tests {
     use super::*;

--- a/rust/src/schema.rs
+++ b/rust/src/schema.rs
@@ -110,7 +110,6 @@ impl Registry {
     }
 }
 
-/*********************************/
 #[cfg(test)]
 mod schema_tests {
     use super::*;

--- a/rust/src/store.rs
+++ b/rust/src/store.rs
@@ -92,7 +92,6 @@ impl Store {
     }
 }
 
-/*********************************/
 #[cfg(test)]
 mod store_tests {
     use super::*;

--- a/rust/src/value.rs
+++ b/rust/src/value.rs
@@ -100,7 +100,6 @@ impl<T: Into<Value>> From<Vec<T>> for Value {
     }
 }
 
-/*********************************/
 #[cfg(test)]
 mod value_tests {
     use super::*;

--- a/transports/_bridge.py
+++ b/transports/_bridge.py
@@ -74,9 +74,6 @@ def from_value(value: Any, cls: Type[M]) -> M:
     return msgspec.convert(plain, cls)  # dataclass or msgspec.Struct
 
 
-# --- schema derivation ---------------------------------------------------------------------------
-
-
 def _annotations(cls: type) -> dict:
     if issubclass(cls, BaseModel):
         return {name: field.annotation for name, field in cls.model_fields.items()}
@@ -122,8 +119,6 @@ def schema_of(cls: type) -> dict:
         "fields": [{"name": name, "ty": _field_type(ann)} for name, ann in _annotations(cls).items()],
     }
 
-
-# --- shared schema artifact: TS codegen (Phase 1.4) ----------------------------------------------
 
 _TS_TYPES = {
     "Bool": "boolean",

--- a/transports/hub.py
+++ b/transports/hub.py
@@ -35,9 +35,6 @@ WRITE = "write"
 SHARED_ID_BASE = 1 << 40
 
 
-# --- merge strategies ----------------------------------------------------------------------------
-
-
 class MergeStrategy:
     """How a write to a shared model is reconciled into its authoritative value.
 
@@ -99,9 +96,6 @@ class LwwMapCrdt(MergeStrategy):
         return new
 
 
-# --- hub ------------------------------------------------------------------------------------------
-
-
 class _Shared:
     """Authoritative state for a shared data structure."""
 
@@ -130,8 +124,6 @@ class Hub:
         self._conn_key: Dict[Any, Any] = {}
         self._codecs: Dict[Any, str] = {}
         self._shared_outbox: List[tuple] = []  # (sid, fan_patch) from host-side writes
-
-    # --- registration ----------------------------------------------------------------------------
 
     def tenant(self, key: Any) -> Session:
         """Get (or create) the `Session` holding a tenant's private models."""
@@ -165,12 +157,8 @@ class Hub:
         self.tenant(tenant_key)  # ensure the tenant exists
         self._shared[sid].subs[tenant_key] = mode
 
-    # --- per-connection encoding -----------------------------------------------------------------
-
     def _encode_for(self, conn: Any, msg_json: str) -> Wire:
         return protocol.encode(msg_json, self._codecs.get(conn, self._default_codec))
-
-    # --- connection lifecycle --------------------------------------------------------------------
 
     def open(self, conn: Any, codec: Optional[str] = None) -> List[Wire]:
         """Register a connection; returns the snapshots of its tenant's private + subscribed shared models."""
@@ -246,8 +234,6 @@ class Hub:
         self._conn_key.pop(conn, None)
         self._codecs.pop(conn, None)
 
-    # --- shared write internals ------------------------------------------------------------------
-
     def _write_shared(self, sid: int, patch: dict, origin: Any) -> Optional[dict]:
         """Merge a write into a shared model; return the authoritative fan-out patch (or None)."""
         sh = self._shared[sid]
@@ -264,8 +250,6 @@ class Hub:
         sh = self._shared[sid]
         msg = protocol.patch_msg(sid, fan)
         return {c: [self._encode_for(c, msg)] for c, k in self._conn_key.items() if k in sh.subs}
-
-    # --- async I/O adapter -----------------------------------------------------------------------
 
     def endpoint(self):
         """Build a Starlette WebSocket endpoint that serves this hub (tenant from `key(websocket)`)."""

--- a/transports/server.py
+++ b/transports/server.py
@@ -84,9 +84,6 @@ class Server:
         self._codecs.pop(conn, None)
 
 
-# --- async I/O adapters --------------------------------------------------------------------------
-
-
 async def _send(conn: Any, msg: Wire) -> None:
     if isinstance(msg, (bytes, bytearray)):
         await conn.send_bytes(msg)

--- a/transports/tests/test_codec.py
+++ b/transports/tests/test_codec.py
@@ -40,8 +40,6 @@ def test_unknown_codec_raises():
         encode_as(MODEL, "application/protobuf")
 
 
-# --- whole-message JSON <-> msgpack (protocol framing) -------------------------------------------
-
 MSG = json.dumps({"t": "patch", "id": 7, "patch": {"rev": 2, "ops": []}})
 
 
@@ -69,8 +67,6 @@ def test_normalize_codec_aliases():
     with pytest.raises(ValueError):
         protocol.normalize_codec("application/protobuf")
 
-
-# --- custom codec registration -------------------------------------------------------------------
 
 CUSTOM = "application/x-test"
 

--- a/transports/tests/test_connection.py
+++ b/transports/tests/test_connection.py
@@ -10,9 +10,6 @@ class Device(BaseModel):
     on: bool = False
 
 
-# --- transport-agnostic logic (no network) -------------------------------------------------------
-
-
 def test_snapshot_then_patch_mirrors_server():
     session = Session()
     server = Server(session)
@@ -116,9 +113,6 @@ def test_two_clients_converge_on_server_rev():
     assert a.value(mid) == b.value(mid)
 
 
-# --- codec negotiation ---------------------------------------------------------------------------
-
-
 def test_msgpack_connection_mirrors_with_binary_frames():
     session = Session()
     server = Server(session)
@@ -205,9 +199,6 @@ def test_starlette_msgpack_connection():
         edit = client.edit(mid, to_value(Device(name="lamp", on=True)))
         assert isinstance(edit, bytes)
         ws.send_bytes(edit)
-
-
-# --- real Starlette WebSocket I/O ----------------------------------------------------------------
 
 
 def test_starlette_connect_snapshot_and_relay():

--- a/transports/tests/test_hub.py
+++ b/transports/tests/test_hub.py
@@ -13,9 +13,6 @@ def hub() -> Hub:
     return Hub(key=lambda c: c[0])
 
 
-# --- tenant routing + isolation ------------------------------------------------------------------
-
-
 def test_private_models_are_tenant_isolated():
     h = hub()
     h.tenant("t1").host(Doc(x=1))
@@ -52,9 +49,6 @@ def test_private_edit_relays_only_within_tenant():
     assert ca2.value(1)["Map"]["x"] == {"Int": 7}
 
 
-# --- 1-N: one shared model, many READ subscribers ------------------------------------------------
-
-
 def test_shared_read_fanout_to_many_tenants():
     h = hub()
     sid = h.share(Doc())
@@ -87,9 +81,6 @@ def test_read_only_subscriber_cannot_write():
     edit = '{"t":"patch","id":%d,"patch":{"rev":1,"ops":[{"Set":{"path":[{"Key":"x"}],"value":{"Int":9}}}]}}' % sid
     assert h.recv(c, edit) == {}  # write ignored
     assert h._shared[sid].value["Map"]["x"] == {"Int": 0}  # authoritative value untouched
-
-
-# --- N-1 / N-N: many WRITE subscribers -----------------------------------------------------------
 
 
 def test_shared_write_relays_to_other_writers():
@@ -130,9 +121,6 @@ def test_n_by_n_routes_each_connection_its_subscribed_set():
     assert len(out[c2]) == 1  # only b
 
 
-# --- merge strategies ----------------------------------------------------------------------------
-
-
 def test_crdt_converges_regardless_of_order():
     base = {"Map": {"x": {"Int": 0}}}
     # two writes to the same key from the same base revision, different origins
@@ -160,9 +148,6 @@ def test_crdt_preserves_concurrent_edits_to_different_keys():
     merged = crdt.merge(crdt.merge(base, px, "A"), py, "B")
     assert merged["Map"]["x"] == {"Int": 1}
     assert merged["Map"]["y"] == {"Int": 1}  # neither write clobbered the other
-
-
-# --- real Starlette WebSockets -------------------------------------------------------------------
 
 
 def test_starlette_two_tenants_share_over_mixed_codecs():

--- a/transports/tests/test_kinds.py
+++ b/transports/tests/test_kinds.py
@@ -29,9 +29,6 @@ class MDevice(msgspec.Struct):
     meta: MSub = msgspec.field(default_factory=MSub)
 
 
-# --- dataclasses ---------------------------------------------------------------------------------
-
-
 def test_dataclass_round_trip():
     d = DCDevice(name="lamp", on=True, meta=DCSub(label="x", tags=["a"]))
     v = to_value(d)
@@ -56,9 +53,6 @@ def test_dataclass_reactive_auto():
     ops = patches[0][1]["ops"]
     assert {"Set": {"path": [{"Key": "on"}], "value": {"Bool": True}}} in ops
     assert {"Set": {"path": [{"Key": "meta"}, {"Key": "label"}], "value": {"Str": "b"}}} in ops
-
-
-# --- msgspec -------------------------------------------------------------------------------------
 
 
 def test_msgspec_round_trip():


### PR DESCRIPTION
Strip section-divider comments and `/*****/` separators across the codebase — no behavior change.

## What
- Rust core (`rust/src/{value,diff,store,bridge,codec,schema,frame}.rs`): drop the `/*****/` block separators between sections.
- Python package (`transports/{_bridge,server,hub}.py`) and test modules (`transports/tests/{test_kinds,test_hub,test_connection,test_codec}.py`): drop `# --- … ---` dividers.
- 14 files, 30 deletions, comments only.

## Why
Decorative dividers add visual noise and drift from the code they label; the module/section structure already reads from the symbols.

## Verification
- `cargo test -p transports`: 29 passed
- `pytest transports/tests`: 59 passed
- `cargo fmt` + `ruff format/check` clean