### PR TITLE
Add an anywidget adapter (serve_anywidget / flush_anywidget)

### DIFF
--- a/transports/__init__.py
+++ b/transports/__init__.py
@@ -1,5 +1,6 @@
 from . import protocol
 from ._bridge import from_value, schema_of, schema_to_ts, to_value
+from .anywidget import flush_anywidget, serve_anywidget
 from .client import Client
 from .comm import pump_comms, serve_comm
 from .hub import READ, WRITE, Hub, LastWriteWins, LwwMapCrdt, MergeStrategy
@@ -49,6 +50,8 @@ __all__ = [
     "sse_endpoint",
     "serve_comm",
     "pump_comms",
+    "serve_anywidget",
+    "flush_anywidget",
     "protocol",
     # multi-tenancy + sharing
     "Hub",

--- a/transports/anywidget.py
+++ b/transports/anywidget.py
@@ -1,0 +1,72 @@
+"""Serve a `Server`/`Hub` over an anywidget (ipywidgets `DOMWidget`) — the widget *is* the connection.
+
+Like `serve_comm`, but for an anywidget's custom-message channel rather than a raw Jupyter comm: the
+wire rides ``widget.send({"wire": <wire>})`` outbound and the widget's ``on_msg`` inbound. The frontend
+signals ``{"ready": true}`` once its view exists; only then are the opening snapshots sent (a view that
+isn't listening yet would miss them). The same `Client.recv`/`edit` run unchanged on the frontend.
+
+This never imports `anywidget`/`ipywidgets`: it duck-types the widget (``send`` / ``on_msg``), so it is
+testable with a fake widget and keeps the Jupyter dependency on the caller.
+
+```python
+import transports
+
+session = transports.Session(); session.host(model)
+server = transports.Server(session)
+
+transports.serve_anywidget(server, my_widget)   # wires ready->snapshots + inbound
+# ... mutate model(s) ...
+transports.flush_anywidget(server)              # push host-side changes to the widget(s)
+```
+"""
+
+from typing import Any
+
+from .server import Broadcaster
+
+
+class _WidgetConn:
+    """An anywidget as a transports connection handle: a wire becomes ``widget.send({"wire": wire})``."""
+
+    __slots__ = ("widget",)
+
+    def __init__(self, widget: Any) -> None:
+        self.widget = widget
+
+    def send(self, wire: Any) -> None:
+        self.widget.send({"wire": wire})
+
+
+def serve_anywidget(server: Broadcaster, widget: Any, codec: str = "json") -> _WidgetConn:
+    """Wire a widget to a `Server`/`Hub`. Returns the connection handle (pass it to `flush_anywidget`).
+
+    The widget's custom messages drive the protocol: ``{"ready": true}`` triggers the opening snapshots,
+    and any ``{"wire": <wire>}`` is relayed to ``server.recv`` (a client's edits), with results sent back
+    over the relevant widgets.
+    """
+    conn = _WidgetConn(widget)
+    opened = []
+
+    def _on_msg(_widget: Any, content: Any, _buffers: Any = None) -> None:
+        if not isinstance(content, dict):
+            return
+        if content.get("ready") and not opened:
+            opened.append(True)
+            for wire in server.open(conn, codec):
+                conn.send(wire)
+        elif "wire" in content:
+            for target, msgs in server.recv(conn, content["wire"]).items():
+                for msg in msgs:
+                    target.send(msg)
+
+    widget.on_msg(_on_msg)
+    return conn
+
+
+def flush_anywidget(server: Broadcaster) -> None:
+    """Flush host-side changes and push the resulting patches to every connected widget.
+
+    Call after mutating hosted models (e.g. from a kernel-loop timer, or at the end of a cell)."""
+    for conn, msgs in server.flush().items():
+        for msg in msgs:
+            conn.send(msg)

--- a/transports/tests/test_anywidget.py
+++ b/transports/tests/test_anywidget.py
@@ -1,0 +1,70 @@
+import json
+
+from pydantic import BaseModel
+
+import transports
+
+
+class FakeWidget:
+    """Duck-typed anywidget: records sent messages, delivers fired ones to on_msg handlers."""
+
+    def __init__(self):
+        self._handlers = []
+        self.sent = []
+
+    def on_msg(self, cb):
+        self._handlers.append(cb)
+
+    def send(self, content, buffers=None):
+        self.sent.append(content)
+
+    def fire(self, content):
+        for cb in self._handlers:
+            cb(self, content, [])
+
+
+class Model(BaseModel):
+    x: int = 0
+
+
+def _wires(widget):
+    return [json.loads(m["wire"]) for m in widget.sent]
+
+
+def test_ready_sends_snapshot_then_flush_sends_patch():
+    model = Model()
+    session = transports.Session()
+    session.host(model)
+    server = transports.Server(session)
+
+    widget = FakeWidget()
+    transports.serve_anywidget(server, widget)
+
+    # nothing sent until the frontend is ready
+    assert widget.sent == []
+
+    widget.fire({"ready": True})
+    wires = _wires(widget)
+    assert len(wires) == 1 and wires[0]["t"] == "snapshot"
+
+    model.x = 5
+    transports.flush_anywidget(server)
+    wires = _wires(widget)
+    assert wires[-1]["t"] == "patch"
+
+
+def test_inbound_edit_is_relayed_back_authoritatively():
+    model = Model()
+    session = transports.Session()
+    mid = session.host(model)
+    server = transports.Server(session)
+
+    widget = FakeWidget()
+    transports.serve_anywidget(server, widget)
+    widget.fire({"ready": True})
+
+    # a client-proposed patch comes back over the wire; the server echoes the authoritative patch
+    proposal = {"rev": 0, "ops": [{"Set": {"path": [{"Key": "x"}], "value": {"Int": 9}}}]}
+    widget.fire({"wire": json.dumps({"t": "patch", "id": mid, "patch": proposal})})
+    assert _wires(widget)[-1]["t"] == "patch"
+    assert model.x == 9  # the hosted model was refreshed from the authoritative apply


### PR DESCRIPTION
Harvested from building daggre's ipywidgets host: every anywidget consumer was re-rolling the same glue (ready-handshake + widget-as-connection + a kernel-loop pump) on top of `Server`. This ships it once.

## What
- `transports/anywidget.py` — `serve_anywidget(server, widget)` wires a `Server`/`Hub` over an anywidget's custom-message channel (the widget *is* the connection; wire rides `widget.send({wire})` / `on_msg`). A `{"ready": true}` from the frontend triggers the opening snapshots (so a not-yet-listening view doesn't miss them). `flush_anywidget(server)` pushes host-side changes.
- Mirrors `serve_comm`/`pump_comms` for the anywidget transport. **Duck-typed** — no `anywidget`/`ipywidgets` import, so it's testable with a fake widget and keeps the Jupyter dep on the caller.

## Why
A notebook consumer should write `transports.serve_anywidget(server, self)` + a pump, not ~40 lines of comm plumbing. The same `Client.recv`/`edit` run unchanged on the frontend.

## Verification
- `pytest transports/tests`: 61 passed (+2): ready→snapshot, flush→patch, and an inbound edit relayed authoritatively.