### PR TITLE
Address review findings (transports)

### DIFF
--- a/js/src/ts/client.ts
+++ b/js/src/ts/client.ts
@@ -42,6 +42,10 @@ export class Client {
       this.values.set(msg.id, msg.value);
       this.revs.set(msg.id, msg.rev);
     } else if (msg.t === "patch") {
+      // rev is the model's sequence number; ignore a patch already reflected in the mirror (e.g. one
+      // the opening snapshot already captured, which the server then also broadcasts).
+      const seen = this.revs.get(msg.id);
+      if (seen !== undefined && msg.patch.rev <= seen) return;
       const cur = JSON.stringify(this.values.get(msg.id));
       this.values.set(
         msg.id,

--- a/js/tests/import.test.js
+++ b/js/tests/import.test.js
@@ -153,6 +153,8 @@ test("Client.edit is send-only; mirror updates on the server echo", async () => 
   expect(c.value(1)).toEqual({ Map: { on: { Bool: false } } });
   // ...the mirror updates when the server echoes the authoritative patch back. The server owns rev
   // and bumps it past the mirror's; a patch at or below the mirror's rev is ignored as already-applied.
-  c.recv(JSON.stringify({ t: "patch", id: 1, patch: { ...msg.patch, rev: 1 } }));
+  c.recv(
+    JSON.stringify({ t: "patch", id: 1, patch: { ...msg.patch, rev: 1 } }),
+  );
   expect(c.value(1)).toEqual({ Map: { on: { Bool: true } } });
 });

--- a/js/tests/import.test.js
+++ b/js/tests/import.test.js
@@ -151,7 +151,8 @@ test("Client.edit is send-only; mirror updates on the server echo", async () => 
   expect(msg.t).toBe("patch");
   // server-authoritative: edit does not mutate the local mirror...
   expect(c.value(1)).toEqual({ Map: { on: { Bool: false } } });
-  // ...the mirror updates when the server echoes the authoritative patch back
-  c.recv(JSON.stringify({ t: "patch", id: 1, patch: msg.patch }));
+  // ...the mirror updates when the server echoes the authoritative patch back. The server owns rev
+  // and bumps it past the mirror's; a patch at or below the mirror's rev is ignored as already-applied.
+  c.recv(JSON.stringify({ t: "patch", id: 1, patch: { ...msg.patch, rev: 1 } }));
   expect(c.value(1)).toEqual({ Map: { on: { Bool: true } } });
 });

--- a/rust/src/bridge.rs
+++ b/rust/src/bridge.rs
@@ -21,7 +21,7 @@ pub fn diff_json(old: &str, new: &str) -> Result<String, String> {
 pub fn apply_json(value: &str, patch: &str) -> Result<String, String> {
     let mut value: Value = serde_json::from_str(value).map_err(|e| e.to_string())?;
     let patch: Patch = serde_json::from_str(patch).map_err(|e| e.to_string())?;
-    apply(&mut value, &patch);
+    apply(&mut value, &patch)?;
     serde_json::to_string(&value).map_err(|e| e.to_string())
 }
 
@@ -107,7 +107,7 @@ impl JsonStore {
     /// Apply a JSON patch to a mirrored model; returns whether the id was known.
     pub fn apply(&mut self, id: u64, patch_json: &str) -> Result<bool, String> {
         let patch: Patch = serde_json::from_str(patch_json).map_err(|e| e.to_string())?;
-        Ok(self.inner.apply(ModelId(id), &patch))
+        self.inner.apply(ModelId(id), &patch)
     }
 }
 

--- a/rust/src/diff.rs
+++ b/rust/src/diff.rs
@@ -187,14 +187,20 @@ fn apply_op(root: &mut Value, op: &Op) -> Result<(), String> {
         Op::Insert { path, index, value } => {
             let list = value_at_mut(root, path)?.try_as_list_mut()?;
             if *index > list.len() {
-                return Err(format!("insert index {index} out of bounds (len {})", list.len()));
+                return Err(format!(
+                    "insert index {index} out of bounds (len {})",
+                    list.len()
+                ));
             }
             list.insert(*index, value.clone());
         }
         Op::RemoveAt { path, index } => {
             let list = value_at_mut(root, path)?.try_as_list_mut()?;
             if *index >= list.len() {
-                return Err(format!("remove index {index} out of bounds (len {})", list.len()));
+                return Err(format!(
+                    "remove index {index} out of bounds (len {})",
+                    list.len()
+                ));
             }
             list.remove(*index);
         }

--- a/rust/src/diff.rs
+++ b/rust/src/diff.rs
@@ -67,11 +67,14 @@ pub fn diff(old: &Value, new: &Value) -> Patch {
     Patch { rev: 0, ops }
 }
 
-/// Apply a patch to `value` in place.
-pub fn apply(value: &mut Value, patch: &Patch) {
+/// Apply a patch to `value` in place. Returns `Err` if the patch is malformed (a path descends into
+/// the wrong type, an index is out of bounds, or a key is missing) so callers can reject untrusted
+/// proposals instead of panicking.
+pub fn apply(value: &mut Value, patch: &Patch) -> Result<(), String> {
     for op in &patch.ops {
-        apply_op(value, op);
+        apply_op(value, op)?;
     }
+    Ok(())
 }
 
 fn child_path(path: &Path, seg: PathSeg) -> Path {
@@ -135,51 +138,68 @@ fn diff_value(path: &Path, old: &Value, new: &Value, ops: &mut Vec<Op>) {
     }
 }
 
-fn value_at_mut<'a>(root: &'a mut Value, path: &[PathSeg]) -> &'a mut Value {
+fn value_at_mut<'a>(root: &'a mut Value, path: &[PathSeg]) -> Result<&'a mut Value, String> {
     let mut cur = root;
     for seg in path {
         cur = match seg {
-            PathSeg::Key(k) => cur.as_map_mut().get_mut(k).expect("path key exists"),
-            PathSeg::Index(i) => &mut cur.as_list_mut()[*i],
+            PathSeg::Key(k) => cur
+                .try_as_map_mut()?
+                .get_mut(k)
+                .ok_or_else(|| format!("path key {k:?} not found"))?,
+            PathSeg::Index(i) => cur
+                .try_as_list_mut()?
+                .get_mut(*i)
+                .ok_or_else(|| format!("path index {i} out of bounds"))?,
         };
     }
-    cur
+    Ok(cur)
 }
 
-fn apply_op(root: &mut Value, op: &Op) {
+fn apply_op(root: &mut Value, op: &Op) -> Result<(), String> {
     match op {
         Op::Set { path, value } => {
             if path.is_empty() {
                 *root = value.clone();
-                return;
+                return Ok(());
             }
-            let (last, parent) = path.split_last().unwrap();
-            let container = value_at_mut(root, parent);
+            let (last, parent) = path.split_last().unwrap(); // non-empty: checked just above
+            let container = value_at_mut(root, parent)?;
             match last {
                 PathSeg::Key(k) => {
-                    container.as_map_mut().insert(k.clone(), value.clone());
+                    container.try_as_map_mut()?.insert(k.clone(), value.clone());
                 }
                 PathSeg::Index(i) => {
-                    container.as_list_mut()[*i] = value.clone();
+                    let slot = container
+                        .try_as_list_mut()?
+                        .get_mut(*i)
+                        .ok_or_else(|| format!("set index {i} out of bounds"))?;
+                    *slot = value.clone();
                 }
             }
         }
         Op::Remove { path } => {
-            let (last, parent) = path.split_last().expect("remove path is non-empty");
-            let container = value_at_mut(root, parent);
+            let (last, parent) = path.split_last().ok_or("remove path is empty")?;
+            let container = value_at_mut(root, parent)?;
             if let PathSeg::Key(k) = last {
-                container.as_map_mut().remove(k);
+                container.try_as_map_mut()?.remove(k);
             }
         }
         Op::Insert { path, index, value } => {
-            value_at_mut(root, path)
-                .as_list_mut()
-                .insert(*index, value.clone());
+            let list = value_at_mut(root, path)?.try_as_list_mut()?;
+            if *index > list.len() {
+                return Err(format!("insert index {index} out of bounds (len {})", list.len()));
+            }
+            list.insert(*index, value.clone());
         }
         Op::RemoveAt { path, index } => {
-            value_at_mut(root, path).as_list_mut().remove(*index);
+            let list = value_at_mut(root, path)?.try_as_list_mut()?;
+            if *index >= list.len() {
+                return Err(format!("remove index {index} out of bounds (len {})", list.len()));
+            }
+            list.remove(*index);
         }
     }
+    Ok(())
 }
 
 #[cfg(test)]
@@ -190,7 +210,7 @@ mod diff_tests {
     fn round_trip(old: &Value, new: &Value) -> Patch {
         let patch = diff(old, new);
         let mut got = old.clone();
-        apply(&mut got, &patch);
+        apply(&mut got, &patch).unwrap();
         assert_eq!(
             &got, new,
             "round-trip failed\n old={old:#?}\n new={new:#?}\n patch={patch:#?}"
@@ -301,7 +321,7 @@ mod diff_tests {
             let new = gen_value(&mut rng, 4);
             let patch = diff(&old, &new);
             let mut got = old.clone();
-            apply(&mut got, &patch);
+            apply(&mut got, &patch).unwrap();
             assert_eq!(
                 got, new,
                 "fuzz failed\n old={old:#?}\n new={new:#?}\n patch={patch:#?}"

--- a/rust/src/store.rs
+++ b/rust/src/store.rs
@@ -67,15 +67,16 @@ impl Store {
         Some(patch)
     }
 
-    /// Apply a peer's patch to a mirrored model, adopting the patch's `rev`.
-    pub fn apply(&mut self, id: ModelId, patch: &Patch) -> bool {
+    /// Apply a peer's patch to a mirrored model, adopting the patch's `rev`. `Err` if the patch is
+    /// malformed (so an untrusted proposal can be rejected rather than panicking the core).
+    pub fn apply(&mut self, id: ModelId, patch: &Patch) -> Result<bool, String> {
         match self.models.get_mut(&id) {
             Some(held) => {
-                apply_patch(&mut held.value, patch);
+                apply_patch(&mut held.value, patch)?;
                 held.rev = patch.rev;
-                true
+                Ok(true)
             }
-            None => false,
+            None => Ok(false),
         }
     }
 
@@ -138,7 +139,7 @@ mod store_tests {
         let patch = server
             .mutate(id, Value::map([("on", Value::from(true))]))
             .unwrap();
-        client.apply(cid, &patch);
+        client.apply(cid, &patch).unwrap();
         assert_eq!(
             client.snapshot(cid).unwrap().1,
             &Value::map([("on", Value::from(true))])

--- a/rust/src/value.rs
+++ b/rust/src/value.rs
@@ -36,20 +36,20 @@ pub enum Value {
 }
 
 impl Value {
-    /// Borrow as a map, panicking if this value is not a map. Used by [`crate::apply`] where the
-    /// patch path guarantees the type.
-    pub fn as_map_mut(&mut self) -> &mut BTreeMap<String, Value> {
+    /// Borrow as a map, or `Err` if this value is not a map. Used by [`crate::apply`] to reject a
+    /// patch whose path descends into the wrong type instead of panicking.
+    pub fn try_as_map_mut(&mut self) -> Result<&mut BTreeMap<String, Value>, String> {
         match self {
-            Value::Map(m) => m,
-            other => panic!("expected Value::Map, found {other:?}"),
+            Value::Map(m) => Ok(m),
+            other => Err(format!("expected Value::Map, found {other:?}")),
         }
     }
 
-    /// Borrow as a list, panicking if this value is not a list.
-    pub fn as_list_mut(&mut self) -> &mut Vec<Value> {
+    /// Borrow as a list, or `Err` if this value is not a list.
+    pub fn try_as_list_mut(&mut self) -> Result<&mut Vec<Value>, String> {
         match self {
-            Value::List(l) => l,
-            other => panic!("expected Value::List, found {other:?}"),
+            Value::List(l) => Ok(l),
+            other => Err(format!("expected Value::List, found {other:?}")),
         }
     }
 

--- a/transports/anywidget.py
+++ b/transports/anywidget.py
@@ -22,6 +22,7 @@ transports.flush_anywidget(server)              # push host-side changes to the 
 
 from typing import Any
 
+from . import protocol
 from .server import Broadcaster
 
 
@@ -44,6 +45,8 @@ def serve_anywidget(server: Broadcaster, widget: Any, codec: str = "json") -> _W
     and any ``{"wire": <wire>}`` is relayed to ``server.recv`` (a client's edits), with results sent back
     over the relevant widgets.
     """
+    if protocol.normalize_codec(codec) != protocol.JSON:
+        raise ValueError(f"the anywidget transport carries JSON-able data only; codec {codec!r} is not supported")
     conn = _WidgetConn(widget)
     opened = []
 

--- a/transports/client.py
+++ b/transports/client.py
@@ -37,8 +37,13 @@ class Client:
             self._type[mid] = msg["type"]
             self._rev[mid] = msg["rev"]
         elif msg["t"] == "patch":
+            rev = msg["patch"]["rev"]
+            # rev is the model's sequence number; ignore a patch already reflected in the mirror (e.g. a
+            # patch the opening snapshot already captured, which the server then also broadcasts).
+            if mid in self._rev and rev <= self._rev[mid]:
+                return
             self._values[mid] = json.loads(_apply(json.dumps(self._values[mid]), json.dumps(msg["patch"])))
-            self._rev[mid] = msg["patch"]["rev"]
+            self._rev[mid] = rev
 
     def value(self, mid: int) -> Any:
         """The current mirrored core `Value` of a model."""

--- a/transports/comm.py
+++ b/transports/comm.py
@@ -35,6 +35,8 @@ def serve_comm(server: Broadcaster, comm: Any, codec: str = protocol.JSON) -> An
     ``server.recv`` and any resulting messages are sent back over the relevant comms. Returns the comm
     (the connection handle), so the caller can `pump_comms(server)` after host-side mutations.
     """
+    if protocol.normalize_codec(codec) != protocol.JSON:
+        raise ValueError(f"the comm transport carries JSON-able data only; codec {codec!r} is not supported")
     for wire in server.open(comm, codec):
         comm.send(data=wire)
 

--- a/transports/session.py
+++ b/transports/session.py
@@ -114,12 +114,16 @@ class Session:
             return None
         cur_rev = json.loads(snap)["rev"]
         authoritative = {"rev": cur_rev + 1, "ops": patch.get("ops", [])}
-        self._apply_authoritative(mid, authoritative)
+        if not self._apply_authoritative(mid, authoritative):
+            return None  # reject a malformed proposal (bad path/type/index) without crashing the host
         return authoritative
 
     def _apply_authoritative(self, mid: int, patch: dict) -> bool:
-        if not self._store.apply(mid, json.dumps(patch)):
-            return False
+        try:
+            if not self._store.apply(mid, json.dumps(patch)):
+                return False
+        except ValueError:
+            return False  # the core rejected a malformed patch (bad path/type/index)
         self._refresh_model(mid)
         return True
 

--- a/transports/tests/test_adapter_codec.py
+++ b/transports/tests/test_adapter_codec.py
@@ -1,0 +1,32 @@
+import pytest
+
+import transports
+
+
+class _FakeWidget:
+    def on_msg(self, cb):
+        pass
+
+    def send(self, *args, **kwargs):
+        pass
+
+
+class _FakeComm:
+    def send(self, *args, **kwargs):
+        pass
+
+    def on_msg(self, cb):
+        pass
+
+    def on_close(self, cb):
+        pass
+
+
+def test_comm_and_anywidget_adapters_reject_non_json_codecs():
+    # these transports carry JSON-able data only; a binary codec would send raw bytes the frontend
+    # can't decode from comm/custom-message data, so the adapters reject it up front.
+    server = transports.Server(transports.Session())
+    with pytest.raises(ValueError):
+        transports.serve_anywidget(server, _FakeWidget(), codec="msgpack")
+    with pytest.raises(ValueError):
+        transports.serve_comm(server, _FakeComm(), codec="msgpack")

--- a/transports/tests/test_apply_safety.py
+++ b/transports/tests/test_apply_safety.py
@@ -1,0 +1,29 @@
+from pydantic import BaseModel
+
+import transports
+
+
+class M(BaseModel):
+    x: int = 0
+
+
+def test_submit_rejects_malformed_patch_without_crashing():
+    """A malformed client proposal (path descends into the wrong type) is rejected, not applied — and
+    it must not panic/abort the host (the core now returns a recoverable error)."""
+    m = M()
+    sess = transports.Session()
+    mid = sess.host(m)
+
+    # descend into x (an Int) as if it were a map -> previously aborted the process at the Rust boundary
+    bad = {"rev": 0, "ops": [{"Set": {"path": [{"Key": "x"}, {"Key": "y"}], "value": {"Int": 9}}}]}
+    assert sess.submit(mid, bad) is None  # dropped
+
+    # out-of-bounds index is also rejected, not a crash
+    bad_index = {"rev": 0, "ops": [{"RemoveAt": {"path": [], "index": 5}}]}
+    assert sess.submit(mid, bad_index) is None
+
+    # the session is still usable, and a valid proposal still goes through
+    good = {"rev": 0, "ops": [{"Set": {"path": [{"Key": "x"}], "value": {"Int": 7}}}]}
+    auth = sess.submit(mid, good)
+    assert auth is not None
+    assert m.x == 7

--- a/transports/tests/test_client_rev.py
+++ b/transports/tests/test_client_rev.py
@@ -1,0 +1,33 @@
+from pydantic import BaseModel
+
+import transports
+
+
+class M(BaseModel):
+    xs: list = []
+
+
+def test_client_ignores_patch_at_or_below_mirror_rev():
+    """A client whose snapshot already reflects a change must not re-apply the broadcast of that change.
+
+    Reproduces the late-join bug: a connection opening after `xs` changed gets a snapshot at the new
+    rev, then the server also broadcasts that change's patch; without rev-idempotency the mirror would
+    end at [1, 2, 2].
+    """
+    m = M(xs=[1])
+    sess = transports.Session()
+    mid = sess.host(m)
+
+    m.xs = m.xs + [2]
+    (_, patch_a) = sess.flush()[0]  # the append-2 patch (broadcast to existing connections)
+    snap = sess.snapshot(mid)  # a newly opened connection's snapshot already includes [1, 2] at this rev
+
+    c = transports.Client()
+    c.recv(transports.protocol.snapshot_msg(mid, snap["type_name"], snap["rev"], snap["value"]))
+    c.recv(transports.protocol.patch_msg(mid, patch_a))  # rev already reflected -> ignored
+    assert transports.from_value(c.value(mid), M).xs == [1, 2]  # not [1, 2, 2]
+
+    m.xs = m.xs + [3]
+    (_, patch_b) = sess.flush()[0]  # a genuinely newer patch
+    c.recv(transports.protocol.patch_msg(mid, patch_b))
+    assert transports.from_value(c.value(mid), M).xs == [1, 2, 3]  # newer rev still applies


### PR DESCRIPTION
Actioning the transports ultrareview (both HIGHs were reproduced):

- **HIGH — duplicate patch on late join.** A connection opening after a model changed received that change in its opening snapshot *and* then again as a broadcast patch, corrupting non-idempotent mirrors (a list ended at `[1, 2, 2]`). `rev` is the model's sequence number, so `Client.recv` (Python **and** JS) now ignores a patch whose rev is `<=` the mirror's rev. Robust regardless of server over-send; covers Server and Hub. + a test reproducing the late-join.
- **HIGH — malformed patch aborts the core.** An inbound patch whose path descends into the wrong type / an out-of-bounds index / a missing key panicked the Rust `apply` and **aborted the process** (confirmed). The apply path now returns a recoverable error (`try_as_map_mut`/`try_as_list_mut` + bounds checks instead of `as_*_mut`/`expect`/indexing); the PyO3 bridge already maps `Err` → `ValueError`, and `Session.submit` now drops a malformed proposal instead of applying it. + a test (the repro returns `None` and the process survives).
- **Med — comm/anywidget codec.** Both adapters carry JSON-able data only; they now reject a non-JSON codec up front rather than sending raw bytes the frontend can't decode. + a test.

## Verification
- `cargo test -p transports`: 29
- `pytest transports/tests`: 64 (+3)
- ruff clean; `tsc --noEmit` clean for the JS client