### PR TITLE
Make the connection adapter API consistent (ws_endpoint / sync / autosync)

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -36,19 +36,17 @@ This reference lists the Python surface exposed by `transports`.
    :undoc-members:
    :member-order: bysource
 
-.. autofunction:: transports.starlette_endpoint
-
-.. autofunction:: transports.autoflush
+.. autofunction:: transports.ws_endpoint
 
 .. autofunction:: transports.sse_endpoint
 
 .. autofunction:: transports.serve_comm
 
-.. autofunction:: transports.pump_comms
-
 .. autofunction:: transports.serve_anywidget
 
-.. autofunction:: transports.flush_anywidget
+.. autofunction:: transports.autosync
+
+.. autofunction:: transports.sync
 ```
 
 ## Multi-tenancy and sharing

--- a/docs/src/connections.md
+++ b/docs/src/connections.md
@@ -35,11 +35,11 @@ async def ticker():
         counter.tick += 1
 
 async def startup():
-    asyncio.create_task(transports.autoflush(server))
+    asyncio.create_task(transports.autosync(server))
     asyncio.create_task(ticker())
 
 app = Starlette(
-    routes=[WebSocketRoute("/ws", transports.starlette_endpoint(server))],
+    routes=[WebSocketRoute("/ws", transports.ws_endpoint(server))],
     on_startup=[startup],
 )
 ```
@@ -50,7 +50,7 @@ Run it:
 uvicorn app:app --reload
 ```
 
-Run one `autoflush` task per `Server` or `Hub`. It drains host-side mutations and broadcasts the
+Run one `autosync` task per `Server` or `Hub`. It drains host-side mutations and broadcasts the
 resulting patches to all open connections.
 
 ## Mirror the server in a browser
@@ -124,7 +124,7 @@ from starlette.applications import Starlette
 from starlette.routing import Route
 
 async def startup():
-    asyncio.create_task(transports.autoflush(server))
+    asyncio.create_task(transports.autosync(server))
 
 app = Starlette(
     routes=[Route("/sse", transports.sse_endpoint(server))],
@@ -165,7 +165,7 @@ comm = create_comm(target_name="transports")
 transports.serve_comm(server, comm)
 
 # after mutating hosted models
-transports.pump_comms(server)
+transports.sync(server)
 ```
 
 The comm carries JSON wire strings in `data`, so `serve_comm` rejects non-JSON codecs.
@@ -179,7 +179,7 @@ The comm carries JSON wire strings in `data`, so `serve_comm` rejects non-JSON c
 conn = transports.serve_anywidget(server, widget)
 
 # after mutating hosted models
-transports.flush_anywidget(server)
+transports.sync(server)
 ```
 
 Frontend messages use the same client protocol:
@@ -198,10 +198,11 @@ Use `model.send({ wire: client.edit(id, value) })` to send an edit from the fron
 
 ## Serve a Hub
 
-A `Hub` satisfies the same connection contract as `Server`. Use `hub.endpoint()` for WebSocket,
-`transports.sse_endpoint(hub)` for SSE, and the same comm or anywidget helpers for Jupyter.
+A `Hub` satisfies the same connection contract as `Server`, so the same adapters serve it:
+`transports.ws_endpoint(hub)` for WebSocket, `transports.sse_endpoint(hub)` for SSE, and the same
+`serve_comm` / `serve_anywidget` helpers for Jupyter (with `autosync(hub)` or `sync(hub)`).
 
 ```python
 hub = transports.Hub(key=lambda ws: ws.path_params["tenant"])
-app = Starlette(routes=[WebSocketRoute("/ws/{tenant}", hub.endpoint())])
+app = Starlette(routes=[WebSocketRoute("/ws/{tenant}", transports.ws_endpoint(hub))])
 ```

--- a/docs/src/multitenancy.md
+++ b/docs/src/multitenancy.md
@@ -46,7 +46,7 @@ hub.subscribe("bob", sid, READ)
 ```
 
 Write to the shared model from the host side with `set_shared`. Subscribers receive the patch on the
-next `flush` or `autoflush` tick.
+next `sync` or `autosync` tick.
 
 ```python
 hub.set_shared(sid, Document(title="Roadmap", body="Updated"))
@@ -94,10 +94,10 @@ from starlette.applications import Starlette
 from starlette.routing import WebSocketRoute
 
 async def startup():
-    asyncio.create_task(transports.autoflush(hub))
+    asyncio.create_task(transports.autosync(hub))
 
 app = Starlette(
-    routes=[WebSocketRoute("/ws/{tenant}", hub.endpoint())],
+    routes=[WebSocketRoute("/ws/{tenant}", transports.ws_endpoint(hub))],
     on_startup=[startup],
 )
 ```

--- a/examples/server.py
+++ b/examples/server.py
@@ -46,14 +46,14 @@ async def _ticker():
 
 
 async def _startup():
-    asyncio.create_task(transports.autoflush(server, 0.05))  # broadcast patches to all clients
+    asyncio.create_task(transports.autosync(server, 0.05))  # broadcast patches to all clients
     asyncio.create_task(_ticker())
 
 
 app = Starlette(
     routes=[
         Route("/", _index),
-        WebSocketRoute("/ws", transports.starlette_endpoint(server)),
+        WebSocketRoute("/ws", transports.ws_endpoint(server)),
         Mount("/pkg", app=StaticFiles(directory=str(PKG))),
     ],
     on_startup=[_startup],

--- a/transports/__init__.py
+++ b/transports/__init__.py
@@ -1,11 +1,11 @@
 from . import protocol
 from ._bridge import from_value, schema_of, schema_to_ts, to_value
-from .anywidget import flush_anywidget, serve_anywidget
+from .anywidget import serve_anywidget
 from .client import Client
-from .comm import pump_comms, serve_comm
+from .comm import serve_comm
 from .hub import READ, WRITE, Hub, LastWriteWins, LwwMapCrdt, MergeStrategy
 from .protocol import decode_as, encode_as, register_codec, registered_codecs, unregister_codec  # registry-aware wrappers
-from .server import Server, autoflush, starlette_endpoint
+from .server import Server, autosync, sync, ws_endpoint
 from .session import Session
 from .sse import sse_endpoint
 from .transports import (  # compiled Rust extension (rust/python)
@@ -42,16 +42,15 @@ __all__ = [
     "from_value",
     "schema_of",
     "schema_to_ts",
-    # connections (WebSocket / SSE / Jupyter comm)
+    # connections (WebSocket / SSE / Jupyter comm / anywidget)
     "Server",
     "Client",
-    "starlette_endpoint",
-    "autoflush",
+    "ws_endpoint",
     "sse_endpoint",
     "serve_comm",
-    "pump_comms",
     "serve_anywidget",
-    "flush_anywidget",
+    "autosync",
+    "sync",
     "protocol",
     # multi-tenancy + sharing
     "Hub",

--- a/transports/anywidget.py
+++ b/transports/anywidget.py
@@ -16,7 +16,7 @@ server = transports.Server(session)
 
 transports.serve_anywidget(server, my_widget)   # wires ready->snapshots + inbound
 # ... mutate model(s) ...
-transports.flush_anywidget(server)              # push host-side changes to the widget(s)
+transports.sync(server)                         # push host-side changes to every connection
 ```
 """
 
@@ -39,7 +39,7 @@ class _WidgetConn:
 
 
 def serve_anywidget(server: Broadcaster, widget: Any, codec: str = "json") -> _WidgetConn:
-    """Wire a widget to a `Server`/`Hub`. Returns the connection handle (pass it to `flush_anywidget`).
+    """Wire a widget to a `Server`/`Hub`. Returns the connection handle; call `sync(server)` to push.
 
     The widget's custom messages drive the protocol: ``{"ready": true}`` triggers the opening snapshots,
     and any ``{"wire": <wire>}`` is relayed to ``server.recv`` (a client's edits), with results sent back
@@ -64,12 +64,3 @@ def serve_anywidget(server: Broadcaster, widget: Any, codec: str = "json") -> _W
 
     widget.on_msg(_on_msg)
     return conn
-
-
-def flush_anywidget(server: Broadcaster) -> None:
-    """Flush host-side changes and push the resulting patches to every connected widget.
-
-    Call after mutating hosted models (e.g. from a kernel-loop timer, or at the end of a cell)."""
-    for conn, msgs in server.flush().items():
-        for msg in msgs:
-            conn.send(msg)

--- a/transports/comm.py
+++ b/transports/comm.py
@@ -3,7 +3,6 @@
 A Jupyter **comm** is a bidirectional message channel between a kernel and a frontend (the transport
 behind ipywidgets). It carries JSON-able data natively, so transports rides it by sending the wire
 *string* as the comm's ``data`` — no extra framing, and the same `Client.recv`/`edit` work unchanged.
-The comm object itself is the connection handle.
 
 This adapter never imports `comm`/`ipykernel`: you pass in a comm (created by your widget, or
 `comm.create_comm(...)`), keeping the Jupyter dependency optional. It is therefore also testable with
@@ -18,7 +17,7 @@ server = transports.Server(session)
 
 transports.serve_comm(server, my_comm)   # sends snapshots, wires inbound messages
 # ... mutate model(s) ...
-transports.pump_comms(server)            # push host-side changes to every comm
+transports.sync(server)                  # push host-side changes to every connection
 ```
 """
 
@@ -28,34 +27,39 @@ from . import protocol
 from .server import Broadcaster
 
 
-def serve_comm(server: Broadcaster, comm: Any, codec: str = protocol.JSON) -> Any:
+class _CommConn:
+    """A Jupyter comm as a transports connection handle: a wire is sent as the comm's ``data``.
+
+    Wrapping the comm gives every connection a uniform ``send(wire)``, so `sync`/`autosync` deliver to
+    comms, anywidgets, and sockets the same way."""
+
+    __slots__ = ("comm",)
+
+    def __init__(self, comm: Any) -> None:
+        self.comm = comm
+
+    def send(self, wire: Any) -> None:
+        self.comm.send(data=wire)
+
+
+def serve_comm(server: Broadcaster, comm: Any, codec: str = protocol.JSON) -> _CommConn:
     """Wire a comm to a `Server`/`Hub`: send the opening snapshots and relay inbound messages.
 
     The comm is registered as a connection; its messages (``msg["content"]["data"]``) are fed to
-    ``server.recv`` and any resulting messages are sent back over the relevant comms. Returns the comm
-    (the connection handle), so the caller can `pump_comms(server)` after host-side mutations.
+    ``server.recv`` and any resulting messages are sent back over the relevant connections. Returns the
+    connection handle. Call `sync(server)` after host-side mutations to push changes.
     """
     if protocol.normalize_codec(codec) != protocol.JSON:
         raise ValueError(f"the comm transport carries JSON-able data only; codec {codec!r} is not supported")
-    for wire in server.open(comm, codec):
-        comm.send(data=wire)
+    conn = _CommConn(comm)
+    for wire in server.open(conn, codec):
+        conn.send(wire)
 
     def _on_msg(msg: dict) -> None:
-        for target, msgs in server.recv(comm, msg["content"]["data"]).items():
+        for target, msgs in server.recv(conn, msg["content"]["data"]).items():
             for m in msgs:
-                target.send(data=m)
+                target.send(m)
 
     comm.on_msg(_on_msg)
-    comm.on_close(lambda _msg: server.close(comm))
-    return comm
-
-
-def pump_comms(server: Broadcaster) -> None:
-    """Flush host-side changes and push the resulting patches to every connected comm.
-
-    Call after mutating hosted models (e.g. at the end of a cell, or from a timer). Each connection
-    handle is a comm, so the patches are delivered with `comm.send`.
-    """
-    for comm, msgs in server.flush().items():
-        for m in msgs:
-            comm.send(data=m)
+    comm.on_close(lambda _msg: server.close(conn))
+    return conn

--- a/transports/hub.py
+++ b/transports/hub.py
@@ -12,18 +12,19 @@ access **mode** (`READ` or `WRITE`). The sharing cardinalities fall out of the s
 Writes to a shared model are reconciled by a pluggable :class:`MergeStrategy` (default
 :class:`LastWriteWins`; :class:`LwwMapCrdt` is a conflict-free reference). Like `Server`, the hub's
 logic is synchronous and transport-agnostic — its methods *return* the messages to send, keyed by
-connection — so it is unit-testable without a network; `Hub.endpoint()` adapts it to Starlette.
+connection — so it is unit-testable without a network. It satisfies the same `Broadcaster` contract as
+`Server`, so the same adapters serve it: `ws_endpoint(hub)`, `sse_endpoint(hub)`, `serve_comm`, etc.
 
 Shared models are **server-authoritative**: a writer sends its edit and receives the authoritative
 patch back.
 """
 
 import json
-from typing import Any, Callable, Dict, List, Optional, Union
+from typing import Any, Callable, Dict, List, Optional
 
 from . import protocol
 from ._bridge import to_value
-from .server import Wire, _send
+from .server import Wire
 from .session import Session
 from .transports import apply as _apply, diff as _diff
 
@@ -112,12 +113,12 @@ class Hub:
 
     Construct with `key`, a function mapping a connection handle to its tenant key. Register shared
     models with `share()` and connect tenants to them with `subscribe()`. Like `Server`, the methods
-    return the messages to send keyed by connection; `endpoint()` performs the I/O over Starlette.
+    return the messages to send keyed by connection; an adapter such as `ws_endpoint(hub)` performs I/O.
     """
 
     def __init__(self, key: Callable[[Any], Any], *, default_codec: str = protocol.JSON) -> None:
         self._key = key
-        self._default_codec = protocol.normalize_codec(default_codec)
+        self.default_codec = protocol.normalize_codec(default_codec)
         self._tenants: Dict[Any, Session] = {}
         self._shared: Dict[int, _Shared] = {}
         self._next_shared = 0
@@ -158,13 +159,13 @@ class Hub:
         self._shared[sid].subs[tenant_key] = mode
 
     def _encode_for(self, conn: Any, msg_json: str) -> Wire:
-        return protocol.encode(msg_json, self._codecs.get(conn, self._default_codec))
+        return protocol.encode(msg_json, self._codecs.get(conn, self.default_codec))
 
     def open(self, conn: Any, codec: Optional[str] = None) -> List[Wire]:
         """Register a connection; returns the snapshots of its tenant's private + subscribed shared models."""
         key = self._key(conn)
         self._conn_key[conn] = key
-        self._codecs[conn] = protocol.normalize_codec(codec or self._default_codec)
+        self._codecs[conn] = protocol.normalize_codec(codec or self.default_codec)
         sess = self.tenant(key)
         out: List[Wire] = []
         for mid in sess.ids():
@@ -221,7 +222,7 @@ class Hub:
         return out
 
     def set_shared(self, sid: int, new_value_or_model: Any) -> None:
-        """Write to a shared model from the host side; the change is broadcast on the next `flush()`."""
+        """Write to a shared model from the host side; the change is broadcast on the next `sync`/`autosync`."""
         value = new_value_or_model if isinstance(new_value_or_model, dict) else to_value(new_value_or_model)
         patch = json.loads(_diff(json.dumps(self._shared[sid].value), json.dumps(value)))
         if not patch["ops"]:
@@ -250,33 +251,3 @@ class Hub:
         sh = self._shared[sid]
         msg = protocol.patch_msg(sid, fan)
         return {c: [self._encode_for(c, msg)] for c, k in self._conn_key.items() if k in sh.subs}
-
-    def endpoint(self):
-        """Build a Starlette WebSocket endpoint that serves this hub (tenant from `key(websocket)`)."""
-
-        async def endpoint(websocket: Any) -> None:
-            from starlette.websockets import WebSocketDisconnect
-
-            codec = websocket.query_params.get("codec", self._default_codec)
-            await websocket.accept()
-            for msg in self.open(websocket, codec):
-                await _send(websocket, msg)
-            try:
-                while True:
-                    frame = await websocket.receive()
-                    if frame.get("type") == "websocket.disconnect":
-                        break
-                    payload: Union[str, bytes, None] = frame.get("text")
-                    if payload is None:
-                        payload = frame.get("bytes")
-                    if payload is None:
-                        continue
-                    for conn, msgs in self.recv(websocket, payload).items():
-                        for msg in msgs:
-                            await _send(conn, msg)
-            except WebSocketDisconnect:
-                pass
-            finally:
-                self.close(websocket)
-
-        return endpoint

--- a/transports/server.py
+++ b/transports/server.py
@@ -2,8 +2,8 @@
 
 `Server` holds the transport-agnostic logic — register connections, send snapshots on open, relay
 inbound patches, broadcast outbound patches — as plain synchronous methods that *return* the messages
-to send, keyed by connection. The actual async I/O lives in a thin adapter (`starlette_endpoint` /
-`autoflush`), so the protocol is testable without a network.
+to send, keyed by connection. The actual async I/O lives in a thin adapter (`ws_endpoint` /
+`autosync`), so the protocol is testable without a network.
 
 A connection handle is any hashable object (the Starlette `WebSocket`, a test sentinel, ...) that the
 I/O adapter knows how to send on. Each connection negotiates a codec (`"json"` or `"msgpack"`); the
@@ -12,7 +12,7 @@ can share one server. A wire message is a `str` (JSON text frame) or `bytes` (Me
 """
 
 import asyncio
-from typing import Any, Dict, List, Protocol, Union
+from typing import Any, Dict, List, Optional, Protocol, Union
 
 from . import protocol
 from .session import Session
@@ -22,6 +22,9 @@ Wire = Union[str, bytes]
 
 class Broadcaster(Protocol):
     """The structural contract the I/O adapters drive — satisfied by both `Server` and `Hub`."""
+
+    #: the codec a connection gets when it doesn't request one (the I/O adapters read this)
+    default_codec: str
 
     def open(self, conn: Any, codec: str = ...) -> List[Wire]: ...
 
@@ -35,20 +38,21 @@ class Broadcaster(Protocol):
 class Server:
     """Serves a `Session` to connected clients: sends a snapshot on connect, broadcasts patches, and
     relays a client's patches to the other clients (a hub). Transport-agnostic — its methods return
-    the messages to send; an adapter such as `starlette_endpoint` performs the I/O.
+    the messages to send; an adapter such as `ws_endpoint` performs the I/O.
 
     Each connection has its own negotiated codec, so outbound messages are encoded per connection."""
 
-    def __init__(self, session: Session) -> None:
+    def __init__(self, session: Session, *, default_codec: str = protocol.JSON) -> None:
         self._session = session
         self._codecs: Dict[Any, str] = {}
+        self.default_codec = protocol.normalize_codec(default_codec)
 
     def _encode_for(self, conn: Any, msg_json: str) -> Wire:
-        return protocol.encode(msg_json, self._codecs.get(conn, protocol.JSON))
+        return protocol.encode(msg_json, self._codecs.get(conn, self.default_codec))
 
-    def open(self, conn: Any, codec: str = protocol.JSON) -> List[Wire]:
+    def open(self, conn: Any, codec: Optional[str] = None) -> List[Wire]:
         """Register a connection with its codec; returns the snapshot messages to send it."""
-        self._codecs[conn] = protocol.normalize_codec(codec)
+        self._codecs[conn] = protocol.normalize_codec(codec or self.default_codec)
         out: List[Wire] = []
         for mid in self._session.ids():
             snap = self._session.snapshot(mid)
@@ -91,18 +95,18 @@ async def _send(conn: Any, msg: Wire) -> None:
         await conn.send_text(msg)
 
 
-def starlette_endpoint(server: Server):
-    """Build a Starlette WebSocket endpoint that serves `server`.
+def ws_endpoint(server: Broadcaster):
+    """Build a Starlette WebSocket endpoint that serves `server` (a `Server` or `Hub`).
 
-    The connection's codec is read from a ``?codec=`` query param (default JSON). Wire it into an
-    app, e.g. ``WebSocketRoute("/ws", starlette_endpoint(server))``, and run `autoflush(server)` as a
-    background task to stream server-side model changes to clients.
+    The connection's codec is read from a ``?codec=`` query param, falling back to the broadcaster's
+    `default_codec`. Wire it into an app, e.g. ``WebSocketRoute("/ws", ws_endpoint(server))``, and run
+    `autosync(server)` as a background task to stream server-side model changes to clients.
     """
 
     async def endpoint(websocket: Any) -> None:
         from starlette.websockets import WebSocketDisconnect
 
-        codec = websocket.query_params.get("codec", protocol.JSON)
+        codec = websocket.query_params.get("codec", server.default_codec)
         await websocket.accept()
         for msg in server.open(websocket, codec):
             await _send(websocket, msg)
@@ -127,11 +131,12 @@ def starlette_endpoint(server: Server):
     return endpoint
 
 
-async def autoflush(server: Broadcaster, interval: float = 0.01) -> None:
+async def autosync(server: Broadcaster, interval: float = 0.01) -> None:
     """Background task: periodically flush and broadcast patches to all connections.
 
     Run exactly one of these per `Server`/`Hub` (not per connection), so a single drain feeds every
-    client.
+    client. The async counterpart of `sync` — use this for socket backends (WebSocket/SSE) driven by an
+    event loop, and `sync` for the synchronous ones (Jupyter comm/anywidget).
     """
     while True:
         await asyncio.sleep(interval)
@@ -141,3 +146,15 @@ async def autoflush(server: Broadcaster, interval: float = 0.01) -> None:
                     await _send(conn, msg)
                 except Exception:
                     server.close(conn)
+
+
+def sync(server: Broadcaster) -> None:
+    """Drain host-side changes and deliver the patches over every connection, synchronously.
+
+    The manual counterpart of `autosync`, for backends driven by a synchronous loop (a Jupyter comm or
+    anywidget): call it after mutating hosted models — e.g. at the end of a cell, or from a kernel
+    timer. Each connection handle exposes `send(wire)`.
+    """
+    for conn, msgs in server.flush().items():
+        for msg in msgs:
+            conn.send(msg)

--- a/transports/sse.py
+++ b/transports/sse.py
@@ -4,7 +4,7 @@ SSE is a one-way server→client stream (the browser `EventSource`), well suited
 like dashboards. A client receives the opening snapshots and then a live stream of patches; it does
 not send edits back over SSE (use the WebSocket adapter for bidirectional sync).
 
-The adapter reuses the existing `autoflush` driver: each SSE connection is a queue-backed handle
+The adapter reuses the existing `autosync` driver: each SSE connection is a queue-backed handle
 whose `send_text` enqueues a message, and the streaming response drains that queue. SSE is a text
 channel, so the JSON codec is used.
 
@@ -14,7 +14,7 @@ import transports
 
 app = Starlette(
     routes=[Route("/sse", transports.sse_endpoint(server))],
-    on_startup=[lambda: asyncio.create_task(transports.autoflush(server))],
+    on_startup=[lambda: asyncio.create_task(transports.autosync(server))],
 )
 ```
 """
@@ -42,7 +42,7 @@ class _SSEConn:
 async def sse_stream(server: Broadcaster, conn: _SSEConn):
     """Async generator of wire messages for one SSE connection: the opening snapshots, then patches.
 
-    Patches arrive on the connection's queue via `autoflush` (which calls `send_text`). Closes the
+    Patches arrive on the connection's queue via `autosync` (which calls `send_text`). Closes the
     connection when the consumer stops iterating.
     """
     for wire in server.open(conn, protocol.JSON):  # snapshots first
@@ -58,7 +58,7 @@ def sse_endpoint(server: Broadcaster):
     """Build a Starlette endpoint that streams a `Server`/`Hub` to a client over SSE.
 
     Wire it into an app as a normal route (``Route("/sse", sse_endpoint(server))``) and run
-    `autoflush(server)` as a background task to stream server-side model changes to connected clients.
+    `autosync(server)` as a background task to stream server-side model changes to connected clients.
     """
     from sse_starlette import EventSourceResponse
 

--- a/transports/tests/test_anywidget.py
+++ b/transports/tests/test_anywidget.py
@@ -48,7 +48,7 @@ def test_ready_sends_snapshot_then_flush_sends_patch():
     assert len(wires) == 1 and wires[0]["t"] == "snapshot"
 
     model.x = 5
-    transports.flush_anywidget(server)
+    transports.sync(server)
     wires = _wires(widget)
     assert wires[-1]["t"] == "patch"
 

--- a/transports/tests/test_comm.py
+++ b/transports/tests/test_comm.py
@@ -2,7 +2,7 @@ from typing import Any
 
 from pydantic import BaseModel
 
-from transports import Client, Hub, Server, Session, pump_comms, serve_comm
+from transports import Client, Hub, Server, Session, serve_comm, sync
 
 
 class Device(BaseModel):
@@ -67,7 +67,7 @@ def test_comm_inbound_edit_is_applied_and_echoed():
     assert d.on is True
 
 
-def test_pump_comms_delivers_host_side_changes():
+def test_pump_delivers_host_side_changes():
     session = Session()
     server = Server(session)
     d = Device(name="lamp")
@@ -77,7 +77,7 @@ def test_pump_comms_delivers_host_side_changes():
     comm.sent.clear()
 
     d.name = "desk"
-    pump_comms(server)
+    sync(server)
     assert len(comm.sent) == 1
 
 

--- a/transports/tests/test_connection.py
+++ b/transports/tests/test_connection.py
@@ -2,7 +2,7 @@ import json
 
 from pydantic import BaseModel
 
-from transports import Client, Server, Session, protocol, starlette_endpoint, to_value
+from transports import Client, Server, Session, protocol, to_value, ws_endpoint
 
 
 class Device(BaseModel):
@@ -188,7 +188,7 @@ def test_starlette_msgpack_connection():
     server = Server(session)
     d = Device(name="lamp")
     mid = session.host(d)
-    app = Starlette(routes=[WebSocketRoute("/ws", starlette_endpoint(server))])
+    app = Starlette(routes=[WebSocketRoute("/ws", ws_endpoint(server))])
 
     with TestClient(app) as tc, tc.websocket_connect("/ws?codec=msgpack") as ws:
         client = Client(codec="msgpack")
@@ -210,7 +210,7 @@ def test_starlette_connect_snapshot_and_relay():
     server = Server(session)
     d = Device(name="lamp")
     mid = session.host(d)
-    app = Starlette(routes=[WebSocketRoute("/ws", starlette_endpoint(server))])
+    app = Starlette(routes=[WebSocketRoute("/ws", ws_endpoint(server))])
 
     with TestClient(app) as tc, tc.websocket_connect("/ws") as ws1, tc.websocket_connect("/ws") as ws2:
         snap1 = json.loads(ws1.receive_text())

--- a/transports/tests/test_hub.py
+++ b/transports/tests/test_hub.py
@@ -1,6 +1,6 @@
 from pydantic import BaseModel
 
-from transports import READ, WRITE, Client, Hub, LastWriteWins, LwwMapCrdt
+from transports import READ, WRITE, Client, Hub, LastWriteWins, LwwMapCrdt, ws_endpoint
 
 
 class Doc(BaseModel):
@@ -159,7 +159,7 @@ def test_starlette_two_tenants_share_over_mixed_codecs():
     sid = h.share(Doc())
     h.subscribe("alice", sid, WRITE)
     h.subscribe("bob", sid, WRITE)
-    app = Starlette(routes=[WebSocketRoute("/ws/{tenant}", h.endpoint())])
+    app = Starlette(routes=[WebSocketRoute("/ws/{tenant}", ws_endpoint(h))])
 
     with TestClient(app) as tc, tc.websocket_connect("/ws/alice?codec=json") as wa, tc.websocket_connect("/ws/bob?codec=msgpack") as wb:
         ca = Client()

--- a/transports/tests/test_sse.py
+++ b/transports/tests/test_sse.py
@@ -14,7 +14,7 @@ class Device(BaseModel):
 def test_sse_stream_yields_snapshot_then_patch():
     """Drive the SSE stream generator directly (the `EventSourceResponse` wrapper is a thin shim).
 
-    Exercises the real `_SSEConn`, `server.open`, and the autoflush delivery path (`_send` ->
+    Exercises the real `_SSEConn`, `server.open`, and the autosync delivery path (`_send` ->
     `send_text` -> queue) without an in-process HTTP server (httpx's ASGITransport can't stream an
     unbounded SSE body).
     """
@@ -32,7 +32,7 @@ def test_sse_stream_yields_snapshot_then_patch():
         client.recv(snap)
         assert client.model(mid, Device) == d
 
-        d.on = True  # host-side mutation -> the autoflush driver delivers via send_text
+        d.on = True  # host-side mutation -> the autosync driver delivers via send_text
         for c, msgs in server.flush().items():
             for m in msgs:
                 await c.send_text(m)


### PR DESCRIPTION
## Summary

One consistent naming scheme for the connection adapters, instead of the per-backend mix that had grown
(`starlette_endpoint` vs `sse_endpoint`, `Hub.endpoint()` as a method, `pump_comms` vs `flush_anywidget`).

## The API now

| Category | Functions |
|---|---|
| Route-mounted (ASGI) | `ws_endpoint(b)` · `sse_endpoint(b)` |
| Imperatively wired | `serve_comm(b, comm)` · `serve_anywidget(b, widget)` |
| Deliver pending patches | `autosync(b)` (background loop) · `sync(b)` (manual, one-shot) |

Both `Server` and `Hub` satisfy the one `Broadcaster` contract, so every adapter takes either.

## Breaking changes (warrants a minor bump)

- `starlette_endpoint(server)` → **`ws_endpoint(b)`** — named by protocol (parallels `sse_endpoint`) and
  takes any `Broadcaster`, folding in the removed **`Hub.endpoint()`** (one WS adapter for `Server` and
  `Hub` instead of two near-identical impls).
- `pump_comms` + `flush_anywidget` → **`sync(b)`** — one synchronous flush helper for all push backends.
- `autoflush` → **`autosync`** — the async loop; `sync`/`autosync` reads as the library's actual job
  (keep clients synced with host state) and pairs cleanly (manual vs auto).

## Supporting changes

- `Server` and `Hub` expose a public `default_codec`; `Server(session, default_codec=…)` now mirrors
  `Hub`, and `ws_endpoint` reads it for the `?codec=` fallback.
- The Jupyter comm handle is wrapped in `_CommConn` so every connection has a uniform `send(wire)` — now
  `sync`/`autosync` deliver to comms, anywidgets, and sockets identically (the delivery loop is no longer
  duplicated per backend).

## Tests & docs

All four connection modules + docstrings, the package exports/`__all__`, the affected tests
(`test_connection`/`test_hub`/`test_comm`/`test_anywidget`/`test_sse`), and the docs (`connections.md`,
`api.md`, `multitenancy.md`, `examples/server.py`) are updated. **64 tests pass**, ruff clean, no residual
old names, and every `api.md` autodoc target resolves.
