### PR TITLE
Remove roadmap phase references from the codebase

### DIFF
--- a/rust/src/codec.rs
+++ b/rust/src/codec.rs
@@ -1,6 +1,6 @@
 //! Wire codecs. [`Codec`] is the seam that makes the format pluggable; [`JsonCodec`] is the
-//! bring-up implementation. Binary codecs (MessagePack, Protobuf, FlatBuffers) are Phase 2 and slot
-//! in behind this same trait without touching the model or diff layers.
+//! bring-up implementation. Binary codecs (MessagePack, Protobuf, FlatBuffers) slot in behind this
+//! same trait without touching the model or diff layers.
 
 use crate::diff::Patch;
 use crate::value::Value;
@@ -80,7 +80,7 @@ impl Codec for MsgpackCodec {
     }
 }
 
-/// Look up a codec by its content-type tag — the seam codec negotiation (Phase 2.1) builds on.
+/// Look up a codec by its content-type tag — the seam codec negotiation builds on.
 pub fn codec_for(content_type: &str) -> Option<Box<dyn Codec>> {
     match content_type {
         "application/json" => Some(Box::new(JsonCodec)),

--- a/rust/src/diff.rs
+++ b/rust/src/diff.rs
@@ -9,7 +9,7 @@
 //! ```
 //!
 //! exercised by a deterministic fuzz below. Maps diff by key; lists diff positionally (keyed-by-id
-//! list reconciliation for `Submodel` lists is a Phase 1 refinement). A type change at a path
+//! list reconciliation for `Submodel` lists is a later refinement). A type change at a path
 //! replaces the value there wholesale.
 
 use serde::{Deserialize, Serialize};

--- a/rust/src/frame.rs
+++ b/rust/src/frame.rs
@@ -7,8 +7,8 @@
 //!
 //! [`Frame::encode`] produces a self-delimiting, length-prefixed byte string so frames can be
 //! streamed back-to-back over a byte transport (TCP, a WebSocket binary message, …); [`Frame::decode`]
-//! reads one frame and returns the remaining bytes. The header is itself JSON for now; Phase 3
-//! connections build on this, and Phase 2 binary codecs only change the *payload*, not the framing.
+//! reads one frame and returns the remaining bytes. The header is itself JSON for now; richer
+//! connections build on this, and binary codecs only change the *payload*, not the framing.
 
 use serde::{Deserialize, Serialize};
 

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -2,7 +2,7 @@
 //!
 //! This crate is the single source of truth for the model representation, the diff/patch engine,
 //! the codecs, and the wire envelope; it compiles into the PyO3 (`rust/python`) and wasm (`js`)
-//! bindings so Python and JavaScript share one implementation. See `transports/ROADMAP.md`, Phase 0.
+//! bindings so Python and JavaScript share one implementation.
 //!
 //! Layers (bottom-up):
 //! - [`value`] — the typed [`Value`] a model is made of, with [`ModelId`] submodel references.

--- a/rust/src/schema.rs
+++ b/rust/src/schema.rs
@@ -3,7 +3,7 @@
 //! A [`Schema`] describes a model type's fields; the [`Registry`] maps a registered type name to
 //! its schema. This ports the prototype's `model_map` (class-name → type), which let the receiving
 //! side reconstruct a model from a `model_type` hint on the wire. Validation is intentionally
-//! lenient for Phase 0 — it checks shape, not exhaustive types.
+//! lenient for now — it checks shape, not exhaustive types.
 
 use std::collections::BTreeMap;
 

--- a/rust/src/store.rs
+++ b/rust/src/store.rs
@@ -5,7 +5,7 @@
 //! [`Patch`] to send to peers — this is the reactive core: a field change becomes an incremental
 //! update with no whole-model resend. [`Store::apply`] applies a peer's patch to a mirrored model.
 //!
-//! Full sessions — fan-out to many subscribers, backpressure, authorization — are Phase 4; this is
+//! Full sessions — fan-out to many subscribers, backpressure, authorization — are future work; this is
 //! the single-owner nucleus they grow from.
 
 use std::collections::BTreeMap;

--- a/transports/_bridge.py
+++ b/transports/_bridge.py
@@ -8,8 +8,7 @@ Supports three model kinds with one contract — **pydantic** models, stdlib **d
   `{"Map": {...}}`). We obtain JSON-native python (pydantic `model_dump(mode="json")`, else via
   `msgspec`) and tag it; the inverse strips tags and lets the model library validate/coerce.
 - `schema_of` derives a core `Schema` (type_name + fields) from the model class.
-- `schema_to_ts` renders that schema as a TypeScript interface — one schema, both languages
-  (Phase 1.4).
+- `schema_to_ts` renders that schema as a TypeScript interface — one schema, both languages.
 
 Nested models are inlined as `Map`s; `Submodel`-by-id references are a later refinement.
 """

--- a/transports/session.py
+++ b/transports/session.py
@@ -6,7 +6,7 @@ dirty; `flush()` (also invoked by `drain()`/`snapshot()`) recomputes each dirty 
 diffs it against the core's held value, and emits the minimal `Patch`. Because emission is deferred
 to a flush, several writes between flushes coalesce into a single patch.
 
-This is the single-owner reactive nucleus; the Phase 4 multi-tenant session (in the Rust core) will
+This is the single-owner reactive nucleus; the multi-tenant session (in the Rust core) will
 back it with fan-out, backpressure, and authorization.
 """
 

--- a/transports/tests/test_all.py
+++ b/transports/tests/test_all.py
@@ -3,7 +3,7 @@ import json
 from transports import Store, apply, decode, diff, encode
 
 # A model is a `Value`; on the wire that is the externally-tagged enum, e.g. a map of fields is
-# {"Map": {"on": {"Bool": false}}}. The pydantic/msgspec bridge (Phase 1) will hide this; the tests
+# {"Map": {"on": {"Bool": false}}}. The pydantic/msgspec bridge will hide this; the tests
 # speak the raw wire form directly.
 
 


### PR DESCRIPTION
Phase numbers (`Phase 0`/`1`/`2`/`3`/`4` and sub-steps like `Phase 2.1`, `Phase 1.4`) are internal roadmap bookkeeping that don't belong in source comments or docstrings — they go stale and mean nothing to a reader of the code. And `rust/src/lib.rs` referenced `transports/ROADMAP.md`, which is **never committed** (it's a symlink into a separate preferences repo), so that reference dangles for anyone who clones.

Rewrites each reference **topically** (what the thing *is*, not which roadmap step ships it) across the Rust core (`codec`/`diff`/`frame`/`lib`/`schema`/`store`) and the Python package (`_bridge`/`session`/a test) — e.g. "are Phase 2" → "slot in behind this same trait", "Phase 4 multi-tenant session" → "the multi-tenant session", and the `ROADMAP.md` pointer dropped.

The roadmap doc itself (`ROADMAP.md` / `AGENTS.md`, both git-ignored symlinks) is untouched, and a demo document literally *titled* "Roadmap" in `multitenancy.md` is left as-is.

Comment/docstring-only; no behavior change. rustfmt + `ruff format` clean; `git grep` for phase/roadmap (excluding the ignored symlinks) is now empty.