### PR TITLE
Add a built-in CBOR codec (ciborium)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,6 +21,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
+
+[[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
+]
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -239,6 +283,7 @@ checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 name = "transports"
 version = "0.4.0"
 dependencies = [
+ "ciborium",
  "rmp-serde",
  "serde",
  "serde_json",
@@ -309,6 +354,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4e0100b01e9f0d03189a92b96772a1fb998639d981193d7dbab487302513441"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/js/src/rust/lib.rs
+++ b/js/src/rust/lib.rs
@@ -51,6 +51,18 @@ pub fn msgpack_to_json(data: &[u8]) -> Result<String, JsError> {
     transports::msgpack_to_json(data).map_err(|e| JsError::new(&e))
 }
 
+/// Convert an arbitrary JSON document to CBOR bytes (a `Uint8Array` in JS).
+#[wasm_bindgen]
+pub fn json_to_cbor(json: &str) -> Result<Vec<u8>, JsError> {
+    transports::json_to_cbor(json).map_err(|e| JsError::new(&e))
+}
+
+/// Convert CBOR bytes back to a JSON document.
+#[wasm_bindgen]
+pub fn cbor_to_json(data: &[u8]) -> Result<String, JsError> {
+    transports::cbor_to_json(data).map_err(|e| JsError::new(&e))
+}
+
 /// In-process model store: host / mutate → patch / apply / snapshot.
 #[wasm_bindgen]
 pub struct Store {

--- a/js/src/ts/client.ts
+++ b/js/src/ts/client.ts
@@ -1,5 +1,12 @@
 import { codecFor } from "./codecs";
-import { apply, diff, jsonToMsgpack, msgpackToJson } from "./index";
+import {
+  apply,
+  cborToJson,
+  diff,
+  jsonToCbor,
+  jsonToMsgpack,
+  msgpackToJson,
+} from "./index";
 
 type SnapshotMsg = {
   t: "snapshot";
@@ -33,11 +40,17 @@ export class Client {
    */
   recv(data: string | Uint8Array): void {
     const custom = codecFor(this.codec);
-    const msg = (
-      custom
-        ? custom.decode(data)
-        : JSON.parse(typeof data === "string" ? data : msgpackToJson(data))
-    ) as SnapshotMsg | PatchMsg;
+    let msg: SnapshotMsg | PatchMsg;
+    if (custom) {
+      msg = custom.decode(data) as SnapshotMsg | PatchMsg;
+    } else if (typeof data === "string") {
+      msg = JSON.parse(data);
+    } else {
+      // binary frame: disambiguate by the connection's codec (msgpack vs cbor)
+      msg = JSON.parse(
+        this.codec === "cbor" ? cborToJson(data) : msgpackToJson(data),
+      );
+    }
     if (msg.t === "snapshot") {
       this.values.set(msg.id, msg.value);
       this.revs.set(msg.id, msg.rev);
@@ -77,7 +90,9 @@ export class Client {
     const custom = codecFor(this.codec);
     if (custom) return custom.encode(msg);
     const s = JSON.stringify(msg);
-    return this.codec === "msgpack" ? jsonToMsgpack(s) : s;
+    if (this.codec === "msgpack") return jsonToMsgpack(s);
+    if (this.codec === "cbor") return jsonToCbor(s);
+    return s;
   }
 
   /** Connect to a transports server and mirror it. Returns the `WebSocket`. */

--- a/js/src/ts/codecs.ts
+++ b/js/src/ts/codecs.ts
@@ -16,6 +16,8 @@ const BUILTIN = new Set([
   "application/msgpack",
   "x-msgpack",
   "application/x-msgpack",
+  "cbor",
+  "application/cbor",
 ]);
 
 const registry = new Map<

--- a/js/src/ts/index.ts
+++ b/js/src/ts/index.ts
@@ -34,6 +34,13 @@ export const jsonToMsgpack = (json: string): Uint8Array =>
 export const msgpackToJson = (bytes: Uint8Array): string =>
   wasm.msgpack_to_json(bytes);
 
+/** Convert an arbitrary JSON document to CBOR bytes (for whole protocol messages). */
+export const jsonToCbor = (json: string): Uint8Array => wasm.json_to_cbor(json);
+
+/** Convert CBOR bytes back to a JSON document. */
+export const cborToJson = (bytes: Uint8Array): string =>
+  wasm.cbor_to_json(bytes);
+
 /** In-process model store: host / mutate → patch / apply / snapshot. */
 export const Store = wasm.Store;
 

--- a/js/tests/import.test.js
+++ b/js/tests/import.test.js
@@ -8,6 +8,8 @@ import {
   decodeAs,
   jsonToMsgpack,
   msgpackToJson,
+  jsonToCbor,
+  cborToJson,
   registerCodec,
   unregisterCodec,
   Client,
@@ -68,6 +70,48 @@ test("Client mirrors a binary (msgpack) snapshot then patch", async () => {
   );
   c.recv(
     jsonToMsgpack(
+      JSON.stringify({
+        t: "patch",
+        id: 1,
+        patch: {
+          rev: 1,
+          ops: [{ Set: { path: [{ Key: "on" }], value: { Bool: true } } }],
+        },
+      }),
+    ),
+  );
+  expect(c.value(1)).toEqual({ Map: { on: { Bool: true } } });
+});
+
+test("cbor round-trips via encodeAs/decodeAs", async () => {
+  const v = JSON.stringify(toValue({ name: "lamp", on: true, count: 123456 }));
+  const cb = encodeAs(v, "application/cbor");
+  expect(cb instanceof Uint8Array).toBe(true);
+  expect(JSON.parse(decodeAs(cb, "application/cbor"))).toEqual(JSON.parse(v));
+});
+
+test("whole-message json<->cbor round-trips", async () => {
+  const msg = JSON.stringify({ t: "patch", id: 7, patch: { rev: 2, ops: [] } });
+  const cb = jsonToCbor(msg);
+  expect(cb instanceof Uint8Array).toBe(true);
+  expect(JSON.parse(cborToJson(cb))).toEqual(JSON.parse(msg));
+});
+
+test("Client mirrors a binary (cbor) snapshot then patch", async () => {
+  const c = new Client("cbor");
+  c.recv(
+    jsonToCbor(
+      JSON.stringify({
+        t: "snapshot",
+        id: 1,
+        type: "Device",
+        rev: 0,
+        value: { Map: { on: { Bool: false } } },
+      }),
+    ),
+  );
+  c.recv(
+    jsonToCbor(
       JSON.stringify({
         t: "patch",
         id: 1,

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -17,3 +17,4 @@ crate-type = ["rlib"]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 rmp-serde = "1"
+ciborium = "0.2"

--- a/rust/python/api/mod.rs
+++ b/rust/python/api/mod.rs
@@ -56,6 +56,19 @@ pub fn msgpack_to_json(data: &[u8]) -> PyResult<String> {
     transports::msgpack_to_json(data).map_err(PyValueError::new_err)
 }
 
+/// Convert an arbitrary JSON document to CBOR bytes (for encoding whole protocol messages).
+#[pyfunction]
+pub fn json_to_cbor<'py>(py: Python<'py>, json: &str) -> PyResult<Bound<'py, PyBytes>> {
+    let bytes = transports::json_to_cbor(json).map_err(PyValueError::new_err)?;
+    Ok(PyBytes::new(py, &bytes))
+}
+
+/// Convert CBOR bytes back to a JSON document.
+#[pyfunction]
+pub fn cbor_to_json(data: &[u8]) -> PyResult<String> {
+    transports::cbor_to_json(data).map_err(PyValueError::new_err)
+}
+
 /// In-process model store: host / mutate → patch / apply / snapshot.
 #[pyclass]
 pub struct Store {

--- a/rust/python/lib.rs
+++ b/rust/python/lib.rs
@@ -13,6 +13,8 @@ fn transports(_py: Python, m: &Bound<PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(api::decode_as, m)?)?;
     m.add_function(wrap_pyfunction!(api::json_to_msgpack, m)?)?;
     m.add_function(wrap_pyfunction!(api::msgpack_to_json, m)?)?;
+    m.add_function(wrap_pyfunction!(api::json_to_cbor, m)?)?;
+    m.add_function(wrap_pyfunction!(api::cbor_to_json, m)?)?;
     m.add_class::<api::Store>()?;
     Ok(())
 }

--- a/rust/src/bridge.rs
+++ b/rust/src/bridge.rs
@@ -67,6 +67,20 @@ pub fn msgpack_to_json(bytes: &[u8]) -> Result<String, String> {
     serde_json::to_string(&v).map_err(|e| e.to_string())
 }
 
+/// Convert an arbitrary JSON document to CBOR bytes (any JSON, like [`json_to_msgpack`]).
+pub fn json_to_cbor(json: &str) -> Result<Vec<u8>, String> {
+    let v: serde_json::Value = serde_json::from_str(json).map_err(|e| e.to_string())?;
+    let mut buf = Vec::new();
+    ciborium::into_writer(&v, &mut buf).map_err(|e| e.to_string())?;
+    Ok(buf)
+}
+
+/// Convert CBOR bytes back to a JSON document.
+pub fn cbor_to_json(bytes: &[u8]) -> Result<String, String> {
+    let v: serde_json::Value = ciborium::from_reader(bytes).map_err(|e| e.to_string())?;
+    serde_json::to_string(&v).map_err(|e| e.to_string())
+}
+
 /// A string-in/string-out facade over [`Store`] for the bindings.
 #[derive(Default)]
 pub struct JsonStore {

--- a/rust/src/codec.rs
+++ b/rust/src/codec.rs
@@ -80,11 +80,43 @@ impl Codec for MsgpackCodec {
     }
 }
 
+/// CBOR via `ciborium`. Compact, self-describing binary — like MessagePack it needs no schema, so it
+/// works with the dynamic [`Value`] as a drop-in for `JsonCodec`.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct CborCodec;
+
+impl Codec for CborCodec {
+    fn encode_value(&self, value: &Value) -> Vec<u8> {
+        let mut buf = Vec::new();
+        ciborium::into_writer(value, &mut buf).expect("Value serializes");
+        buf
+    }
+
+    fn decode_value(&self, bytes: &[u8]) -> Result<Value, CodecError> {
+        ciborium::from_reader(bytes).map_err(|e| CodecError(e.to_string()))
+    }
+
+    fn encode_patch(&self, patch: &Patch) -> Vec<u8> {
+        let mut buf = Vec::new();
+        ciborium::into_writer(patch, &mut buf).expect("Patch serializes");
+        buf
+    }
+
+    fn decode_patch(&self, bytes: &[u8]) -> Result<Patch, CodecError> {
+        ciborium::from_reader(bytes).map_err(|e| CodecError(e.to_string()))
+    }
+
+    fn content_type(&self) -> &'static str {
+        "application/cbor"
+    }
+}
+
 /// Look up a codec by its content-type tag — the seam codec negotiation builds on.
 pub fn codec_for(content_type: &str) -> Option<Box<dyn Codec>> {
     match content_type {
         "application/json" => Some(Box::new(JsonCodec)),
         "application/msgpack" | "application/x-msgpack" => Some(Box::new(MsgpackCodec)),
+        "application/cbor" => Some(Box::new(CborCodec)),
         _ => None,
     }
 }
@@ -128,6 +160,20 @@ mod codec_tests {
     }
 
     #[test]
+    fn test_cbor_round_trip_and_smaller() {
+        let c = CborCodec;
+        let v = Value::map([
+            ("name", Value::from("lamp")),
+            ("on", Value::from(true)),
+            ("count", Value::from(123456i64)),
+        ]);
+        assert_eq!(c.decode_value(&c.encode_value(&v)).unwrap(), v);
+        assert_eq!(c.content_type(), "application/cbor");
+        // self-describing binary (no schema), more compact than JSON
+        assert!(c.encode_value(&v).len() < JsonCodec.encode_value(&v).len());
+    }
+
+    #[test]
     fn test_codec_for() {
         assert_eq!(
             codec_for("application/json").unwrap().content_type(),
@@ -138,6 +184,7 @@ mod codec_tests {
             "application/msgpack"
         );
         assert!(codec_for("application/x-msgpack").is_some());
+        assert!(codec_for("application/cbor").unwrap().content_type() == "application/cbor");
         assert!(codec_for("application/protobuf").is_none());
     }
 

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -22,10 +22,10 @@ mod store;
 mod value;
 
 pub use bridge::{
-    apply_json, decode_as, decode_json, diff_json, encode_as, encode_json, json_to_msgpack,
-    msgpack_to_json, JsonStore,
+    apply_json, cbor_to_json, decode_as, decode_json, diff_json, encode_as, encode_json,
+    json_to_cbor, json_to_msgpack, msgpack_to_json, JsonStore,
 };
-pub use codec::{codec_for, Codec, CodecError, JsonCodec, MsgpackCodec};
+pub use codec::{codec_for, CborCodec, Codec, CodecError, JsonCodec, MsgpackCodec};
 pub use diff::{apply, diff, Op, Patch, Path, PathSeg};
 pub use frame::{Frame, FrameError, FrameKind};
 pub use schema::{Field, FieldType, Registry, Schema};

--- a/transports/__init__.py
+++ b/transports/__init__.py
@@ -11,9 +11,11 @@ from .sse import sse_endpoint
 from .transports import (  # compiled Rust extension (rust/python)
     Store,
     apply,
+    cbor_to_json,
     decode,
     diff,
     encode,
+    json_to_cbor,
     json_to_msgpack,
     msgpack_to_json,
 )
@@ -32,6 +34,8 @@ __all__ = [
     "encode_as",
     "json_to_msgpack",
     "msgpack_to_json",
+    "json_to_cbor",
+    "cbor_to_json",
     # custom wire codecs
     "register_codec",
     "unregister_codec",

--- a/transports/client.py
+++ b/transports/client.py
@@ -19,8 +19,7 @@ class Client:
 
     Read values with `value(id)` or materialize them with `model(id, cls)`. Drive it with a live
     connection via `connect(url)`, or feed it messages directly with `recv(data)`. The `codec`
-    (`"json"` or `"msgpack"`) controls how outbound edits are framed; inbound frames are decoded
-    automatically from their type (text=JSON, binary=msgpack)."""
+    (`"json"`, `"msgpack"`, or `"cbor"`) frames outbound edits and decodes inbound frames."""
 
     def __init__(self, codec: str = protocol.JSON) -> None:
         self._values: Dict[int, Any] = {}

--- a/transports/protocol.py
+++ b/transports/protocol.py
@@ -14,18 +14,21 @@ import json
 from typing import Any, Callable, Dict, Tuple, Union
 
 from .transports import (
+    cbor_to_json as _cbor_to_json,
     decode_as as _core_decode_as,
     encode_as as _core_encode_as,
+    json_to_cbor as _json_to_cbor,
     json_to_msgpack as _json_to_msgpack,
     msgpack_to_json as _msgpack_to_json,
 )
 
 #: Canonical codec names. A connection negotiates one of these (e.g. via a ``?codec=`` query param);
-#: JSON travels as text frames, MessagePack as binary frames.
+#: JSON travels as text frames, MessagePack and CBOR as binary frames.
 JSON = "json"
 MSGPACK = "msgpack"
+CBOR = "cbor"
 
-_BUILTIN = {"", "json", "application/json", "msgpack", "application/msgpack", "x-msgpack", "application/x-msgpack"}
+_BUILTIN = {"", "json", "application/json", "msgpack", "application/msgpack", "x-msgpack", "application/x-msgpack", "cbor", "application/cbor"}
 
 #: Registered custom codecs: ``content_type -> (encode, decode)``. ``encode`` maps a JSON-able object
 #: (a protocol message, or a model ``Value``) to wire bytes/str; ``decode`` is its inverse.
@@ -59,12 +62,14 @@ def registered_codecs() -> Tuple[str, ...]:
 
 
 def normalize_codec(name: Union[str, None]) -> str:
-    """Map a codec name or content-type to a canonical name (:data:`JSON`, :data:`MSGPACK`, or a
-    registered custom content type)."""
+    """Map a codec name or content-type to a canonical name (:data:`JSON`, :data:`MSGPACK`,
+    :data:`CBOR`, or a registered custom content type)."""
     if name in (None, "", "json", "application/json"):
         return JSON
     if name in ("msgpack", "application/msgpack", "x-msgpack", "application/x-msgpack"):
         return MSGPACK
+    if name in ("cbor", "application/cbor"):
+        return CBOR
     if name in _CODECS:
         return name  # a registered content type is its own canonical name
     raise ValueError(f"unknown codec: {name}")
@@ -89,6 +94,8 @@ def encode(msg_json: str, codec: str = JSON) -> Union[str, bytes]:
         return _CODECS[c][0](json.loads(msg_json))
     if c == MSGPACK:
         return _json_to_msgpack(msg_json)
+    if c == CBOR:
+        return _json_to_cbor(msg_json)
     return msg_json
 
 
@@ -104,6 +111,8 @@ def decode(data: Union[str, bytes], codec: Union[str, None] = None) -> dict:
             return _CODECS[c][1](data)
         if c == JSON:
             return json.loads(data)
+        if c == CBOR:
+            return json.loads(_cbor_to_json(bytes(data)))
     if isinstance(data, (bytes, bytearray)):
         return json.loads(_msgpack_to_json(bytes(data)))
     return json.loads(data)

--- a/transports/tests/test_codec.py
+++ b/transports/tests/test_codec.py
@@ -7,9 +7,11 @@ from transports import (
     Client,
     Server,
     Session,
+    cbor_to_json,
     decode_as,
     encode,
     encode_as,
+    json_to_cbor,
     json_to_msgpack,
     msgpack_to_json,
     protocol,
@@ -61,8 +63,31 @@ def test_protocol_encode_decode_msgpack():
     assert protocol.decode(wire) == json.loads(MSG)
 
 
+def test_cbor_round_trip():
+    blob = encode_as(MODEL, "application/cbor")
+    assert isinstance(blob, bytes)
+    assert json.loads(decode_as(blob, "application/cbor")) == json.loads(MODEL)
+
+
+def test_cbor_is_smaller_than_json():
+    assert len(encode_as(MODEL, "application/cbor")) < len(encode(MODEL))
+
+
+def test_json_cbor_message_round_trip():
+    blob = json_to_cbor(MSG)
+    assert isinstance(blob, bytes)
+    assert json.loads(cbor_to_json(blob)) == json.loads(MSG)
+
+
+def test_protocol_encode_decode_cbor():
+    wire = protocol.encode(MSG, protocol.CBOR)
+    assert isinstance(wire, bytes)
+    assert protocol.decode(wire, protocol.CBOR) == json.loads(MSG)
+
+
 def test_normalize_codec_aliases():
     assert protocol.normalize_codec("application/msgpack") == protocol.MSGPACK
+    assert protocol.normalize_codec("application/cbor") == protocol.CBOR
     assert protocol.normalize_codec(None) == protocol.JSON
     with pytest.raises(ValueError):
         protocol.normalize_codec("application/protobuf")

--- a/transports/tests/test_connection.py
+++ b/transports/tests/test_connection.py
@@ -134,6 +134,27 @@ def test_msgpack_connection_mirrors_with_binary_frames():
     assert client.model(mid, Device).on is True
 
 
+def test_cbor_connection_mirrors_with_binary_frames():
+    session = Session()
+    server = Server(session)
+    client = Client(codec="cbor")
+    d = Device(name="lamp")
+    mid = session.host(d)
+
+    snaps = server.open("c1", codec="cbor")
+    assert all(isinstance(m, bytes) for m in snaps)  # CBOR frames are binary
+    for m in snaps:
+        client.recv(m)
+    assert client.model(mid, Device) == d
+
+    d.on = True
+    out = server.flush()["c1"]
+    assert all(isinstance(m, bytes) for m in out)
+    for m in out:
+        client.recv(m)
+    assert client.model(mid, Device).on is True
+
+
 def test_mixed_codecs_per_connection():
     session = Session()
     server = Server(session)


### PR DESCRIPTION
Adds **CBOR** as a built-in wire codec. CBOR is self-describing binary (like MessagePack), so it slots
behind the existing `Codec` trait with no schema — filling the gap between MessagePack (done) and the
schema-driven formats Protobuf/FlatBuffers (2.4/2.5), which the roadmap listed but skipped the other
self-describing binary format.

## What's wired
- **Core** (`rust/src`): `CborCodec` (ciborium) for values + patches, `codec_for("application/cbor")`,
  and `json_to_cbor`/`cbor_to_json` for whole protocol messages (the parallel to
  `json_to_msgpack`/`msgpack_to_json`).
- **Both bindings**: `json_to_cbor`/`cbor_to_json` exposed from PyO3 + wasm; `encode_as`/`decode_as`
  already dispatch via `codec_for`, so `"application/cbor"` works in both.
- **Connection negotiation**: `protocol.py` gains `CBOR`, the `?codec=cbor` / `Client(codec="cbor")`
  path, and per-connection encode/decode — so a CBOR client mirrors a server over binary frames, no
  server change (the `Server` already passes each connection's codec to `protocol.decode`, which is
  required now that two binary codecs exist). JS `Client` + `codecs.ts` mirror it.

Custom codecs were already user-registrable (`register_codec`), so this is about shipping CBOR in-tree
behind the same negotiation.

## Cross-binding
Python and JS both encode through the **same core ciborium**, so their CBOR bytes are identical by
construction — the same guarantee as msgpack.

## Tests (all green)
- **Rust** (30): `CborCodec` round-trip + smaller-than-JSON, `codec_for` recognizes it.
- **Python** (30): value round-trip, message round-trip, `protocol.encode/decode`, `normalize_codec`,
  and an end-to-end **CBOR connection** mirror over a `Server`.
- **JS** (12): value `encodeAs`/`decodeAs`, message round-trip, and a `Client("cbor")` binary mirror.

Roadmap: this is the easy half of Phase 2's remaining codecs; Protobuf/FlatBuffers (schema-driven,
2.4/2.5) and CRDT merge (6.2) remain.