### PR TITLE
Add a field-granular CRDT merge strategy (DeepLwwCrdt)

### DIFF
--- a/transports/__init__.py
+++ b/transports/__init__.py
@@ -3,7 +3,7 @@ from ._bridge import from_value, schema_of, schema_to_ts, to_value
 from .anywidget import serve_anywidget
 from .client import Client
 from .comm import serve_comm
-from .hub import READ, WRITE, Hub, LastWriteWins, LwwMapCrdt, MergeStrategy
+from .hub import READ, WRITE, DeepLwwCrdt, Hub, LastWriteWins, LwwMapCrdt, MergeStrategy
 from .protocol import decode_as, encode_as, register_codec, registered_codecs, unregister_codec  # registry-aware wrappers
 from .server import Server, autosync, sync, ws_endpoint
 from .session import Session
@@ -63,4 +63,5 @@ __all__ = [
     "MergeStrategy",
     "LastWriteWins",
     "LwwMapCrdt",
+    "DeepLwwCrdt",
 ]

--- a/transports/hub.py
+++ b/transports/hub.py
@@ -97,6 +97,42 @@ class LwwMapCrdt(MergeStrategy):
         return new
 
 
+class DeepLwwCrdt(MergeStrategy):
+    """Field-granular conflict-free LWW — an independent last-writer-wins register at **every** map path,
+    not just the top level (cf. :class:`LwwMapCrdt`). Each map-key write carries a logical stamp
+    `(patch rev, origin)` kept per *full path*; a write is accepted only if its stamp is at least the one
+    stored for that exact path. So concurrent edits to **different** fields — however deeply nested — all
+    survive, and conflicting edits to the **same** field converge to the same value regardless of the
+    order the hub receives them.
+
+    Scope: field-granular for scalar/map writes (the leaf ops a `diff` produces for edited fields).
+    List-index ops and whole-subtree replaces fall back to a direct stamped apply — they are not
+    element-granular (an order-free list/text CRDT needs per-element identity; see ROADMAP 6.2).
+    """
+
+    def __init__(self) -> None:
+        self._clock: Dict[tuple, tuple] = {}
+
+    def merge(self, current: Any, patch: dict, origin: Any) -> Any:
+        new = json.loads(json.dumps(current))
+        rev = patch.get("rev", 0)
+        stamp = (rev, str(origin))
+        for op in patch.get("ops", []):
+            kind = next(iter(op))
+            body = op[kind]
+            segs = body.get("path", [])
+            keys = tuple(s["Key"] for s in segs if "Key" in s)
+            if len(keys) != len(segs) or kind not in ("Set", "Remove"):
+                # a list-index op or whole-subtree op — apply directly (not field-granular)
+                new = json.loads(_apply(json.dumps(new), json.dumps({"rev": rev, "ops": [op]})))
+                continue
+            if keys in self._clock and stamp < self._clock[keys]:
+                continue  # stale write to this exact field — drop
+            self._clock[keys] = stamp
+            new = json.loads(_apply(json.dumps(new), json.dumps({"rev": rev, "ops": [op]})))
+        return new
+
+
 class _Shared:
     """Authoritative state for a shared data structure."""
 

--- a/transports/tests/test_hub.py
+++ b/transports/tests/test_hub.py
@@ -1,6 +1,8 @@
+import itertools
+
 from pydantic import BaseModel
 
-from transports import READ, WRITE, Client, Hub, LastWriteWins, LwwMapCrdt, ws_endpoint
+from transports import READ, WRITE, Client, DeepLwwCrdt, Hub, LastWriteWins, LwwMapCrdt, ws_endpoint
 
 
 class Doc(BaseModel):
@@ -148,6 +150,77 @@ def test_crdt_preserves_concurrent_edits_to_different_keys():
     merged = crdt.merge(crdt.merge(base, px, "A"), py, "B")
     assert merged["Map"]["x"] == {"Int": 1}
     assert merged["Map"]["y"] == {"Int": 1}  # neither write clobbered the other
+
+
+_NESTED = {"Map": {"a": {"Map": {"b": {"Int": 0}, "c": {"Int": 0}}}, "z": {"Int": 0}}}
+
+
+def _set(path_keys, value, rev):
+    return {"rev": rev, "ops": [{"Set": {"path": [{"Key": k} for k in path_keys], "value": value}}]}
+
+
+def test_deep_lww_preserves_concurrent_nested_edits():
+    # concurrent writes to a.b and a.c (different nested fields) must both survive
+    crdt = DeepLwwCrdt()
+    merged = crdt.merge(crdt.merge(_NESTED, _set(["a", "b"], {"Int": 1}, 1), "A"), _set(["a", "c"], {"Int": 2}, 1), "B")
+    assert merged["Map"]["a"]["Map"]["b"] == {"Int": 1}
+    assert merged["Map"]["a"]["Map"]["c"] == {"Int": 2}  # neither clobbered the other
+
+
+def test_deep_lww_is_finer_grained_than_lww_map():
+    # contrast: LwwMapCrdt stamps both nested writes under the top key "a", so the lower-stamped one is
+    # dropped; DeepLwwCrdt keeps each field's own register.
+    hi = _set(["a", "b"], {"Int": 1}, 2)  # higher stamp, field a.b
+    lo = _set(["a", "c"], {"Int": 2}, 1)  # lower stamp, different field a.c
+    coarse = LwwMapCrdt()
+    assert coarse.merge(coarse.merge(_NESTED, hi, "A"), lo, "B")["Map"]["a"]["Map"]["c"] == {"Int": 0}  # dropped
+    deep = DeepLwwCrdt()
+    assert deep.merge(deep.merge(_NESTED, hi, "A"), lo, "B")["Map"]["a"]["Map"]["c"] == {"Int": 2}  # kept
+
+
+def test_deep_lww_converges_over_every_order():
+    # writes to distinct field paths, each with its own stamp; every permutation converges (conflict-free)
+    writes = [
+        (_set(["a", "b"], {"Int": 1}, 3), "A"),
+        (_set(["a", "c"], {"Int": 2}, 1), "B"),
+        (_set(["z"], {"Int": 9}, 2), "C"),
+    ]
+    results = []
+    for perm in itertools.permutations(writes):
+        crdt = DeepLwwCrdt()
+        v = _NESTED
+        for patch, origin in perm:
+            v = crdt.merge(v, patch, origin)
+        results.append(v)
+    assert all(r == results[0] for r in results)  # order-independent
+    assert results[0]["Map"]["a"]["Map"]["b"] == {"Int": 1}
+    assert results[0]["Map"]["a"]["Map"]["c"] == {"Int": 2}
+    assert results[0]["Map"]["z"] == {"Int": 9}
+
+
+def test_deep_lww_same_field_converges_by_stamp():
+    # two writes to the SAME nested field; the higher stamp wins, in either arrival order
+    hi = _set(["a", "b"], {"Int": 5}, 2)
+    lo = _set(["a", "b"], {"Int": 4}, 1)
+    a, b = DeepLwwCrdt(), DeepLwwCrdt()
+    v_a = a.merge(a.merge(_NESTED, hi, "A"), lo, "B")
+    v_b = b.merge(b.merge(_NESTED, lo, "B"), hi, "A")
+    assert v_a == v_b
+    assert v_a["Map"]["a"]["Map"]["b"] == {"Int": 5}  # higher (rev 2) wins
+
+
+def test_hub_shares_with_deep_lww_merge():
+    # two WRITE subscribers edit different nested fields of one shared model; both land authoritatively
+    h = hub()
+    sid = h.share({"Map": {"a": {"Map": {"b": {"Int": 0}, "c": {"Int": 0}}}}}, type_name="Nested", merge=DeepLwwCrdt)
+    h.subscribe("t1", sid, WRITE)
+    h.subscribe("t2", sid, WRITE)
+    h.open(("t1", "a"))
+    h.open(("t2", "b"))
+    h.recv(("t1", "a"), '{"t":"patch","id":%d,"patch":{"rev":1,"ops":[{"Set":{"path":[{"Key":"a"},{"Key":"b"}],"value":{"Int":1}}}]}}' % sid)
+    h.recv(("t2", "b"), '{"t":"patch","id":%d,"patch":{"rev":1,"ops":[{"Set":{"path":[{"Key":"a"},{"Key":"c"}],"value":{"Int":2}}}]}}' % sid)
+    shared = h._shared[sid].value["Map"]["a"]["Map"]
+    assert shared["b"] == {"Int": 1} and shared["c"] == {"Int": 2}
 
 
 def test_starlette_two_tenants_share_over_mixed_codecs():


### PR DESCRIPTION
Extends the `Hub`'s `MergeStrategy` seam (roadmap 6.2) with **`DeepLwwCrdt`** — a conflict-free
last-writer-wins register at **every** map path, not just the top level (cf. `LwwMapCrdt`).

## Why
`LwwMapCrdt` stamps per *top-level* key, so two concurrent edits to *different nested fields under the
same key* can wrongly drop each other. `DeepLwwCrdt` keeps a `(rev, origin)` stamp **per full path**, so:
- concurrent edits to different fields — however deeply nested — **all survive**;
- conflicting edits to the **same** field converge to the same value regardless of the order the hub
  receives them.

It fits the value-patch model exactly (patches from `diff` are leaf-addressed). **Scope:** field-granular
for scalar/map writes; list-index ops and whole-subtree replaces fall back to a stamped apply — not
element-granular (an order-free list/text CRDT needs per-element identity; that's the remaining 6.2
stretch, e.g. an external automerge/yrs backend).

## Correctness
Convergence is **property-tested**: every permutation of a set of concurrent writes yields an identical
value. Plus:
- a **contrast** test showing `DeepLwwCrdt` keeps a concurrent nested edit that `LwwMapCrdt` drops;
- same-field conflict converges by stamp in either order;
- an **end-to-end hub** test: two `WRITE` subscribers edit different nested fields of one shared model and
  both land authoritatively.

14 hub tests green (full transports suite 74). Python-only — the merge runs server-side in the `Hub`.