### PR TITLE
Reconnect/resume + a per-model replay log (3.7 + 6.1)

### DIFF
--- a/js/src/ts/client.ts
+++ b/js/src/ts/client.ts
@@ -95,10 +95,21 @@ export class Client {
     return s;
   }
 
-  /** Connect to a transports server and mirror it. Returns the `WebSocket`. */
+  /** Connect to a transports server and mirror it. Returns the `WebSocket`.
+   *
+   * On a reconnect (this client already mirrors models) it appends `?since=` with its last-seen rev per
+   * model, so the server replays only the delta instead of re-sending each whole model.
+   */
   connect(url: string): WebSocket {
     const sep = url.includes("?") ? "&" : "?";
-    const ws = new WebSocket(`${url}${sep}codec=${this.codec}`);
+    let params = `codec=${this.codec}`;
+    if (this.revs.size) {
+      const since = encodeURIComponent(
+        JSON.stringify(Object.fromEntries(this.revs)),
+      );
+      params += `&since=${since}`;
+    }
+    const ws = new WebSocket(`${url}${sep}${params}`);
     ws.binaryType = "arraybuffer";
     ws.addEventListener("message", (e) => {
       const data = (e as MessageEvent).data;

--- a/transports/client.py
+++ b/transports/client.py
@@ -7,6 +7,7 @@ network).
 """
 
 import json
+import urllib.parse
 from typing import Any, Dict, List, Type, Union
 
 from . import protocol
@@ -68,12 +69,16 @@ class Client:
     async def connect(self, url: str) -> None:
         """Connect to a transports server and mirror it until the connection closes.
 
-        Appends ``?codec=`` for the client's codec so the server frames messages to match.
+        Appends ``?codec=`` for the client's codec, and — if this client already mirrors models (a
+        reconnect) — ``?since=`` with its last-seen rev per model, so the server replays only the delta.
         """
         import websockets
 
         sep = "&" if "?" in url else "?"
-        async with websockets.connect(f"{url}{sep}codec={self._codec}") as ws:
+        params = f"codec={self._codec}"
+        if self._rev:  # resume: bring this mirror up to date from where it left off
+            params += "&since=" + urllib.parse.quote(json.dumps(self._rev))
+        async with websockets.connect(f"{url}{sep}{params}") as ws:
             async for frame in ws:
                 self.recv(frame)
 

--- a/transports/hub.py
+++ b/transports/hub.py
@@ -197,16 +197,24 @@ class Hub:
     def _encode_for(self, conn: Any, msg_json: str) -> Wire:
         return protocol.encode(msg_json, self._codecs.get(conn, self.default_codec))
 
-    def open(self, conn: Any, codec: Optional[str] = None) -> List[Wire]:
-        """Register a connection; returns the snapshots of its tenant's private + subscribed shared models."""
+    def open(self, conn: Any, codec: Optional[str] = None, since: Optional[Dict[int, int]] = None) -> List[Wire]:
+        """Register a connection; return the messages to bring it up to date — its tenant's private models
+        and its subscribed shared models. With ``since={mid: last_rev}`` a reconnecting client resumes its
+        **private** models from the delta (shared models re-snapshot — a shared replay log is a follow-on)."""
         key = self._key(conn)
         self._conn_key[conn] = key
         self._codecs[conn] = protocol.normalize_codec(codec or self.default_codec)
         sess = self.tenant(key)
         out: List[Wire] = []
         for mid in sess.ids():
-            snap = sess.snapshot(mid)
-            out.append(self._encode_for(conn, protocol.snapshot_msg(mid, snap["type_name"], snap["rev"], snap["value"])))
+            client_rev = since.get(mid) if since else None
+            delta = sess.since(mid, client_rev) if client_rev is not None else None
+            if delta is not None:
+                for patch in delta:
+                    out.append(self._encode_for(conn, protocol.patch_msg(mid, patch)))
+            else:
+                snap = sess.snapshot(mid)
+                out.append(self._encode_for(conn, protocol.snapshot_msg(mid, snap["type_name"], snap["rev"], snap["value"])))
         for sid, sh in self._shared.items():
             if key in sh.subs:
                 out.append(self._encode_for(conn, protocol.snapshot_msg(sid, sh.type_name, sh.rev, sh.value)))

--- a/transports/server.py
+++ b/transports/server.py
@@ -12,6 +12,7 @@ can share one server. A wire message is a `str` (JSON text frame) or `bytes` (Me
 """
 
 import asyncio
+import json
 from typing import Any, Dict, List, Optional, Protocol, Union
 
 from . import protocol
@@ -26,7 +27,7 @@ class Broadcaster(Protocol):
     #: the codec a connection gets when it doesn't request one (the I/O adapters read this)
     default_codec: str
 
-    def open(self, conn: Any, codec: str = ...) -> List[Wire]: ...
+    def open(self, conn: Any, codec: str = ..., since: Optional[Dict[int, int]] = ...) -> List[Wire]: ...
 
     def recv(self, conn: Any, data: Wire) -> Dict[Any, List[Wire]]: ...
 
@@ -50,14 +51,24 @@ class Server:
     def _encode_for(self, conn: Any, msg_json: str) -> Wire:
         return protocol.encode(msg_json, self._codecs.get(conn, self.default_codec))
 
-    def open(self, conn: Any, codec: Optional[str] = None) -> List[Wire]:
-        """Register a connection with its codec; returns the snapshot messages to send it."""
+    def open(self, conn: Any, codec: Optional[str] = None, since: Optional[Dict[int, int]] = None) -> List[Wire]:
+        """Register a connection; return the messages that bring it up to date.
+
+        Fresh connect (``since=None``) → a snapshot per model. Resume (``since={mid: last_rev}``) → only
+        the patches each model emitted after ``last_rev``, falling back to a snapshot for any model whose
+        replay log can't bridge the gap. So a reconnecting client replays the delta, not the whole model.
+        """
         self._codecs[conn] = protocol.normalize_codec(codec or self.default_codec)
         out: List[Wire] = []
         for mid in self._session.ids():
-            snap = self._session.snapshot(mid)
-            msg = protocol.snapshot_msg(mid, snap["type_name"], snap["rev"], snap["value"])
-            out.append(self._encode_for(conn, msg))
+            client_rev = since.get(mid) if since else None
+            delta = self._session.since(mid, client_rev) if client_rev is not None else None
+            if delta is not None:
+                for patch in delta:
+                    out.append(self._encode_for(conn, protocol.patch_msg(mid, patch)))
+            else:
+                snap = self._session.snapshot(mid)
+                out.append(self._encode_for(conn, protocol.snapshot_msg(mid, snap["type_name"], snap["rev"], snap["value"])))
         return out
 
     def recv(self, conn: Any, data: Wire) -> Dict[Any, List[Wire]]:
@@ -107,8 +118,10 @@ def ws_endpoint(server: Broadcaster):
         from starlette.websockets import WebSocketDisconnect
 
         codec = websocket.query_params.get("codec", server.default_codec)
+        since_param = websocket.query_params.get("since")  # resume token: {mid: last_rev} JSON
+        since = {int(k): int(v) for k, v in json.loads(since_param).items()} if since_param else None
         await websocket.accept()
-        for msg in server.open(websocket, codec):
+        for msg in server.open(websocket, codec, since):
             await _send(websocket, msg)
         try:
             while True:

--- a/transports/session.py
+++ b/transports/session.py
@@ -28,6 +28,8 @@ class Session:
         self._suppress: Set[int] = set()  # ids whose observation is suspended (during inbound apply)
         self.outbox: List[Tuple[int, dict]] = []
         self._on_patch: Optional[Callable[[int, dict], None]] = None
+        self._log: Dict[int, List[Tuple[int, dict]]] = {}  # per-model replay log of (rev, patch), bounded
+        self._log_cap = 512  # patches retained per model for resume; older are evicted (resume → snapshot)
 
     def host(self, model: Any) -> int:
         """Host a model: register its schema, store its value in the core, and watch it. Returns id."""
@@ -61,6 +63,7 @@ class Session:
             if patch["ops"]:
                 self.outbox.append((mid, patch))
                 emitted.append((mid, patch))
+                self._record(mid, patch)
                 if self._on_patch is not None:
                     self._on_patch(mid, patch)
         self._dirty.clear()
@@ -116,7 +119,26 @@ class Session:
         authoritative = {"rev": cur_rev + 1, "ops": patch.get("ops", [])}
         if not self._apply_authoritative(mid, authoritative):
             return None  # reject a malformed proposal (bad path/type/index) without crashing the host
+        self._record(mid, authoritative)
         return authoritative
+
+    def _record(self, mid: int, patch: dict) -> None:
+        """Append a patch to the model's bounded replay log (for resume)."""
+        log = self._log.setdefault(mid, [])
+        log.append((patch["rev"], patch))
+        if len(log) > self._log_cap:
+            del log[: len(log) - self._log_cap]
+
+    def since(self, mid: int, since_rev: int) -> Optional[List[dict]]:
+        """Patches to advance a mirror from `since_rev` to current, or `None` if the log can't bridge the
+        gap (the next needed patch was evicted) — then the caller should send a fresh snapshot instead."""
+        cur = self.snapshot(mid)["rev"]  # flush pending changes (recording them) before reading the log
+        if since_rev >= cur:
+            return []  # already current
+        log = self._log.get(mid, [])
+        if not any(rev == since_rev + 1 for rev, _ in log):
+            return None  # the next needed patch was evicted — gap, can't replay
+        return [patch for rev, patch in log if rev > since_rev]
 
     def _apply_authoritative(self, mid: int, patch: dict) -> bool:
         try:

--- a/transports/tests/test_resume.py
+++ b/transports/tests/test_resume.py
@@ -1,0 +1,65 @@
+import json
+
+from pydantic import BaseModel
+
+from transports import Client, Server, Session
+
+
+class Doc(BaseModel):
+    x: int = 0
+
+
+def _bump(session, mid, value):
+    """Mutate the hosted model and flush, advancing its rev by one."""
+    session._models[mid].x = value
+    session.update(mid)
+
+
+def test_session_since_returns_delta_up_to_date_or_gap():
+    s = Session()
+    mid = s.host(Doc())
+    for v in (1, 2, 3):
+        _bump(s, mid, v)
+    assert s.snapshot(mid)["rev"] == 3
+    assert [p["rev"] for p in s.since(mid, 1)] == [2, 3]  # the patches after rev 1
+    assert s.since(mid, 3) == []  # already current
+    s._log[mid] = s._log[mid][-1:]  # evict all but rev 3 — rev 2 is gone
+    assert s.since(mid, 1) is None  # gap: can't bridge from rev 1, caller must re-snapshot
+
+
+def test_server_resume_replays_only_the_delta():
+    s = Session()
+    mid = s.host(Doc())
+    server = Server(s)
+    client = Client()
+    for m in server.open("c1"):  # fresh connect → snapshot
+        client.recv(m)
+    assert client.model(mid, Doc).x == 0
+    last = client._rev[mid]
+
+    _bump(s, mid, 42)  # model advances while the client is away
+
+    resume = server.open("c2", since={mid: last})  # reconnect with last-seen rev
+    assert resume and all(json.loads(m)["t"] == "patch" for m in resume)  # delta, no snapshot
+    for m in resume:
+        client.recv(m)
+    assert client.model(mid, Doc).x == 42
+
+
+def test_server_resume_falls_back_to_snapshot_on_gap():
+    s = Session()
+    mid = s.host(Doc())
+    server = Server(s)
+    _bump(s, mid, 5)
+    s._log[mid] = []  # log evicted → gap
+    msgs = server.open("c", since={mid: 0})
+    assert json.loads(msgs[0])["t"] == "snapshot"  # falls back to a fresh snapshot
+
+
+def test_resume_when_already_current_sends_nothing():
+    s = Session()
+    mid = s.host(Doc())
+    server = Server(s)
+    _bump(s, mid, 7)
+    cur = s.snapshot(mid)["rev"]
+    assert server.open("c", since={mid: cur}) == []  # nothing to replay


### PR DESCRIPTION
A dropped connection now **resumes from where it left off** instead of re-sending every whole model.

## What
- **Replay log (6.1):** the `Session` keeps a bounded per-model log of `(rev, patch)` (cap 512, oldest
  evicted) and exposes `since(mid, rev)` → the patches emitted after `rev`, or `None` when the log can't
  bridge the gap (the next needed patch was evicted).
- **Resume (3.7):** `Server.open` / `Hub.open` gain `since={mid: last_rev}`. A reconnecting client replays
  **only the delta**, falling back to a snapshot per model whose log was evicted (or sending nothing when
  already current). `ws_endpoint` reads a `?since=` token; `Client.connect` (Python **and** JS) sends its
  last-seen revs on reconnect.

## Tests
`test_resume.py`: `since()` (delta / up-to-date / gap), server resume (delta vs snapshot fallback), and
the up-to-date no-op. Python **78**, JS **12** green.

## Follow-ons (noted in the roadmap)
Shared-model resume in the `Hub` (shared models re-snapshot for now — they have no replay log yet) and
durable-to-disk persistence (the log is in-memory, enabling resume within a server's lifetime).