### PR TITLE
Add an order-free sequence CRDT (SeqCrdt, Logoot-style)

### DIFF
--- a/transports/__init__.py
+++ b/transports/__init__.py
@@ -5,6 +5,7 @@ from .client import Client
 from .comm import serve_comm
 from .hub import READ, WRITE, DeepLwwCrdt, Hub, LastWriteWins, LwwMapCrdt, MergeStrategy
 from .protocol import decode_as, encode_as, register_codec, registered_codecs, unregister_codec  # registry-aware wrappers
+from .seq import SeqCrdt, seq_delete, seq_insert, seq_key_between, seq_materialize, seq_new
 from .server import Server, autosync, sync, ws_endpoint
 from .session import Session
 from .sse import sse_endpoint
@@ -64,4 +65,11 @@ __all__ = [
     "LastWriteWins",
     "LwwMapCrdt",
     "DeepLwwCrdt",
+    # sequence CRDT (order-free)
+    "SeqCrdt",
+    "seq_new",
+    "seq_insert",
+    "seq_delete",
+    "seq_key_between",
+    "seq_materialize",
 ]

--- a/transports/seq.py
+++ b/transports/seq.py
@@ -1,0 +1,92 @@
+"""An order-free **sequence CRDT** (Logoot / fractional-index style) for `Hub` shared models.
+
+A sequence is a JSON string of *entries* — ``{"k": position, "o": origin, "v": value, "x": deleted}`` —
+where ``k`` is a rational position (``"num/den"``) that orders the entry and ``o`` is the writer that
+created it (a tiebreaker, so concurrent inserts into the *same* gap both survive).
+
+Storing the sequence as one opaque **string** (not a structured list) is deliberate: the core diffs lists
+*positionally* — field-level index sets that scramble entry identity under concurrent edits — but a
+string diffs atomically, so a writer's edit arrives as the whole new sequence. :class:`SeqCrdt` then
+merges it as the **union** of entries, with deletions **monotonic** (a tombstone, never resurrected) and
+the result ordered by ``(k, o)`` — so concurrent inserts, deletes, and arbitrary-position edits converge
+regardless of arrival order.
+
+Positions are exact rationals, so there is always a midpoint between any two (:func:`seq_key_between` =
+``(left + right) / 2``). Hold the sequence in a ``str`` model field; edit it with :func:`seq_insert` /
+:func:`seq_delete`; read it with :func:`seq_materialize`. (Values are immutable once placed — an edit is
+delete + insert, the standard sequence-CRDT model. Full RGA with after-references would need keyed-by-id
+list diffs; see ROADMAP 6.2.)
+"""
+
+import json
+from fractions import Fraction
+from typing import Any, List, Optional
+
+from .hub import MergeStrategy
+from .transports import apply as _apply
+
+START, END = Fraction(0), Fraction(1)
+
+
+def seq_key_between(left: Optional[str], right: Optional[str]) -> str:
+    """A rational position strictly between `left` and `right` (`None` = the sequence start / end)."""
+    lo = Fraction(left) if left else START
+    hi = Fraction(right) if right else END
+    mid = (lo + hi) / 2
+    return f"{mid.numerator}/{mid.denominator}"
+
+
+def _ordered(entries: Any) -> list:
+    return sorted(entries, key=lambda e: (Fraction(e["k"]), e["o"]))
+
+
+def seq_new(items: List[Any], origin: Any) -> str:
+    """Build a sequence from `items`, each placed in order and attributed to `origin`."""
+    entries: List[dict] = []
+    left: Optional[str] = None
+    for it in items:
+        k = seq_key_between(left, None)
+        entries.append({"k": k, "o": str(origin), "v": it, "x": False})
+        left = k
+    return json.dumps(entries)
+
+
+def seq_insert(seq: str, item: Any, index: int, origin: Any) -> str:
+    """Insert `item` at live `index` (0 = front, len = end), attributed to `origin`."""
+    entries = _ordered(json.loads(seq))
+    live = [e for e in entries if not e["x"]]
+    left = live[index - 1]["k"] if index > 0 else None
+    right = live[index]["k"] if index < len(live) else None
+    entries.append({"k": seq_key_between(left, right), "o": str(origin), "v": item, "x": False})
+    return json.dumps(_ordered(entries))
+
+
+def seq_delete(seq: str, index: int) -> str:
+    """Tombstone the live item at `index`."""
+    entries = _ordered(json.loads(seq))
+    live = [e for e in entries if not e["x"]]
+    target = live[index]["k"]
+    for e in entries:
+        if e["k"] == target:
+            e["x"] = True
+    return json.dumps(_ordered(entries))
+
+
+def seq_materialize(seq: str) -> list:
+    """The live (non-deleted) values of a sequence, in order."""
+    return [e["v"] for e in _ordered(json.loads(seq)) if not e["x"]]
+
+
+class SeqCrdt(MergeStrategy):
+    """Conflict-free sequence merge: union of positioned entries, deletes monotonic, ordered by `(k, o)`."""
+
+    def merge(self, current: Any, patch: dict, origin: Any) -> Any:
+        applied = json.loads(_apply(json.dumps(current), json.dumps(patch)))  # the writer's whole new sequence
+        merged = {(e["k"], e["o"]): e for e in json.loads(current.get("Str", "[]"))}
+        for e in json.loads(applied.get("Str", "[]")):
+            key = (e["k"], e["o"])
+            if key not in merged:
+                merged[key] = e  # a new insert (its position key is globally unique)
+            elif e["x"]:
+                merged[key] = {**merged[key], "x": True}  # delete-wins (monotonic)
+        return {"Str": json.dumps(_ordered(merged.values()))}

--- a/transports/tests/test_seq.py
+++ b/transports/tests/test_seq.py
@@ -1,0 +1,68 @@
+import itertools
+import json
+
+from transports import SeqCrdt, diff, seq_delete, seq_insert, seq_materialize, seq_new
+
+
+def _val(seq: str) -> dict:
+    return {"Str": seq}  # the core Value for a sequence-holding str field
+
+
+def _patch(old: str, new: str) -> dict:
+    return json.loads(diff(json.dumps(_val(old)), json.dumps(_val(new))))
+
+
+def test_seq_new_and_materialize_round_trip():
+    assert seq_materialize(seq_new(["a", "b", "c"], "base")) == ["a", "b", "c"]
+
+
+def test_concurrent_inserts_into_the_same_gap_both_survive_and_converge():
+    base = seq_new(["a", "c"], "base")
+    pa = _patch(base, seq_insert(base, "X", 1, "A"))  # between a and c
+    pb = _patch(base, seq_insert(base, "Y", 1, "B"))  # same gap, concurrent
+    c1 = SeqCrdt()
+    v1 = c1.merge(c1.merge(_val(base), pa, "A"), pb, "B")
+    c2 = SeqCrdt()
+    v2 = c2.merge(c2.merge(_val(base), pb, "B"), pa, "A")
+    assert seq_materialize(v1["Str"]) == seq_materialize(v2["Str"])  # conflict-free
+    assert seq_materialize(v1["Str"]) == ["a", "X", "Y", "c"]  # both kept; tie broken by origin A < B
+
+
+def test_seq_converges_over_every_order():
+    base = seq_new(["a", "b"], "base")
+    edits = [
+        (_patch(base, seq_insert(base, "1", 0, "A")), "A"),  # front
+        (_patch(base, seq_insert(base, "2", 1, "B")), "B"),  # middle
+        (_patch(base, seq_insert(base, "3", 2, "C")), "C"),  # end
+    ]
+    results = []
+    for perm in itertools.permutations(edits):
+        crdt = SeqCrdt()
+        v = _val(base)
+        for patch, origin in perm:
+            v = crdt.merge(v, patch, origin)
+        results.append(seq_materialize(v["Str"]))
+    assert all(r == results[0] for r in results)  # order-independent
+    assert set(results[0]) == {"a", "b", "1", "2", "3"}  # every insert landed
+    assert results[0][0] == "1" and results[0][-1] == "3"  # front/end placed correctly
+
+
+def test_delete_is_monotonic_and_converges_with_a_concurrent_insert():
+    base = seq_new(["a", "b", "c"], "base")
+    pd = _patch(base, seq_delete(base, 1))  # tombstone "b"
+    pi = _patch(base, seq_insert(base, "X", 2, "B"))  # insert between b and c, concurrently
+    c1 = SeqCrdt()
+    v1 = c1.merge(c1.merge(_val(base), pd, "A"), pi, "B")
+    c2 = SeqCrdt()
+    v2 = c2.merge(c2.merge(_val(base), pi, "B"), pd, "A")
+    assert seq_materialize(v1["Str"]) == seq_materialize(v2["Str"])
+    assert seq_materialize(v1["Str"]) == ["a", "X", "c"]  # b deleted, X kept
+
+
+def test_lww_would_lose_a_concurrent_insert_but_seqcrdt_does_not():
+    base = seq_new(["a", "b"], "base")
+    pa = _patch(base, seq_insert(base, "X", 1, "A"))
+    pb = _patch(base, seq_insert(base, "Y", 1, "B"))
+    crdt = SeqCrdt()
+    merged = crdt.merge(crdt.merge(_val(base), pa, "A"), pb, "B")
+    assert set(seq_materialize(merged["Str"])) == {"a", "b", "X", "Y"}  # neither clobbered


### PR DESCRIPTION
A conflict-free **sequence** merge for `Hub` shared models — the order-free half of roadmap 6.2.

## How
A sequence is a JSON string of positioned entries `{k, o, v, x}`: `k` is an **exact rational** position
(`num/den`), `o` the origin (a tiebreaker). `SeqCrdt` merges as the **union** of entries, deletes
**monotonic** (tombstones), ordered by `(k, o)`. So concurrent inserts (even into the same gap), deletes,
and arbitrary-position edits **all converge** regardless of arrival order.

**Why a string, not a list:** the core diffs lists *positionally* — field-level index `Set`s that scramble
entry identity under concurrent edits (an existing entry gets rewritten into a spurious new one). A string
diffs **atomically**, so a writer's edit arrives as the whole new sequence and the merge unions cleanly.
Positions are exact `Fraction`s, so there's always a midpoint — no fractional-string allocation to get
wrong (`seq_key_between` = `(left + right) / 2`).

Helpers: `seq_new` / `seq_insert` / `seq_delete` / `seq_materialize` (index-based; hold the sequence in a
`str` model field).

## Correctness
Property-tested over **every** write permutation (front/middle/end inserts converge identically); plus
same-gap concurrent inserts, monotonic delete vs concurrent insert, and an LWW-loses-an-insert contrast.
Full transports suite **79** green.

## Follow-on
True collaborative **text** (RGA with after-references, or fully-minimal sequence patches) needs
**keyed-by-id list reconciliation** in the Rust diff engine — the remaining 6.2 stretch.