### PR TITLE
transports: multi-worker clustering — backplane, relay, CRDT convergence, catch-up & durability seams

### DIFF
--- a/transports/__init__.py
+++ b/transports/__init__.py
@@ -1,6 +1,7 @@
 from . import protocol
 from ._bridge import from_value, schema_of, schema_to_ts, to_value
 from .anywidget import serve_anywidget
+from .backplane import Backplane, QueueBackplane, UnixSocketBackplane, ZmqBackplane
 from .client import Client
 from .comm import serve_comm
 from .hub import READ, WRITE, DeepLwwCrdt, Hub, LastWriteWins, LwwMapCrdt, MergeStrategy
@@ -53,6 +54,11 @@ __all__ = [
     "ws_endpoint",
     "sse_endpoint",
     "serve_comm",
+    # cross-process backplane (multi-worker fan-out)
+    "Backplane",
+    "QueueBackplane",
+    "UnixSocketBackplane",
+    "ZmqBackplane",
     "serve_anywidget",
     "autosync",
     "sync",

--- a/transports/__init__.py
+++ b/transports/__init__.py
@@ -6,6 +6,7 @@ from .client import Client
 from .comm import serve_comm
 from .hub import READ, WRITE, DeepLwwCrdt, Hub, LastWriteWins, LwwMapCrdt, MergeStrategy
 from .protocol import decode_as, encode_as, register_codec, registered_codecs, unregister_codec  # registry-aware wrappers
+from .relay import RelayBroadcaster
 from .seq import SeqCrdt, seq_delete, seq_insert, seq_key_between, seq_materialize, seq_new
 from .server import Server, autosync, sync, ws_endpoint
 from .session import Session
@@ -59,6 +60,7 @@ __all__ = [
     "QueueBackplane",
     "UnixSocketBackplane",
     "ZmqBackplane",
+    "RelayBroadcaster",
     "serve_anywidget",
     "autosync",
     "sync",

--- a/transports/backplane.py
+++ b/transports/backplane.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 import asyncio
 import os
 import struct
+import sys
 import threading
 from typing import AsyncIterator
 
@@ -176,6 +177,8 @@ class UnixSocketBackplane(Backplane):
             writer.close()
 
     async def _start(self) -> None:
+        if sys.platform == "win32":  # Unix domain sockets + flock are POSIX-only
+            raise RuntimeError("UnixSocketBackplane requires POSIX; use ZmqBackplane on Windows")
         self.runs_broker = await self._elect()
         reader, self._writer = await self._connect()  # everyone, the binder included, connects a client
         self._task = asyncio.create_task(self._read(reader))

--- a/transports/backplane.py
+++ b/transports/backplane.py
@@ -33,7 +33,7 @@ import threading
 from typing import AsyncIterator
 
 _ID_LEN = 16  # per-instance sender id, prefixed to every frame so a backplane can skip its own messages
-_CLOSE = object()  # sentinel pushed on close() to unblock messages()
+_CLOSE = object()  # sentinel pushed on stop() to unblock messages()
 
 
 class Backplane:
@@ -59,7 +59,7 @@ class Backplane:
         raise NotImplementedError
 
     async def messages(self) -> AsyncIterator[bytes]:
-        """Yield frames published by other processes (never this one), until :meth:`close`."""
+        """Yield frames published by other processes (never this one), until :meth:`stop`."""
         assert self._inbox is not None, "start() the backplane first"
         while not self._closed:
             item = await self._inbox.get()
@@ -67,7 +67,7 @@ class Backplane:
                 break
             yield item
 
-    async def close(self) -> None:
+    async def stop(self) -> None:
         self._closed = True
         if self._inbox is not None:
             self._inbox.put_nowait(_CLOSE)
@@ -135,8 +135,8 @@ class ZmqBackplane(Backplane):
     async def publish(self, data: bytes) -> None:
         await self._pub.send(self._frame(data))
 
-    async def close(self) -> None:
-        await super().close()
+    async def stop(self) -> None:
+        await super().stop()
         if self._task:
             self._task.cancel()
         if self._pub:
@@ -219,8 +219,8 @@ class UnixSocketBackplane(Backplane):
         self._writer.write(struct.pack(">I", len(frame)) + frame)
         await self._writer.drain()
 
-    async def close(self) -> None:
-        await super().close()
+    async def stop(self) -> None:
+        await super().stop()
         if self._task:
             self._task.cancel()
         if self._writer:
@@ -283,8 +283,8 @@ class QueueBackplane(Backplane):
     async def publish(self, data: bytes) -> None:
         self._in.put(self._frame(data))
 
-    async def close(self) -> None:
-        await super().close()
+    async def stop(self) -> None:
+        await super().stop()
         self._out.put(None)  # unblock the executor get
         if self._task:
             self._task.cancel()

--- a/transports/backplane.py
+++ b/transports/backplane.py
@@ -1,0 +1,287 @@
+"""Cross-process backplane: a small bytes pub/sub that relays frames between worker processes.
+
+A single uvicorn/gunicorn worker is one event loop on one core, and the connection fan-out (snapshot
+encode + per-tick send to every client) is what saturates it. Running many workers spreads that I/O
+across cores — but each worker then has its own in-memory model, so a change applied on one worker never
+reaches clients on another. A `Backplane` closes that gap: a worker `publish()`es its frames and
+`messages()` yields what the others publish, so every worker can mirror the same model and fan it to its
+own clients. Concurrency between workers is resolved the usual way — by the `Session`/`Hub` merge
+strategy — since the frames are ordinary transports frames.
+
+`publish(data)` delivers to every *other* process on the bus (a backplane skips its own messages).
+Three transports, by how the workers are launched:
+
+- :class:`QueueBackplane` — ``multiprocessing`` queues. For a parent that spawns its own workers (or a
+  ``gunicorn --preload`` fork): build the bus in the parent and hand each worker its handle. Not
+  address-based, so it does **not** fit ``uvicorn --workers`` (those re-import the app per worker).
+- :class:`UnixSocketBackplane` — a Unix-domain-socket broker. Workers connect by path, so it works with
+  any worker manager (``uvicorn``/``gunicorn --workers``). Brokerless: the first worker to bind the path
+  runs the reflector, the rest connect.
+- :class:`ZmqBackplane` — a ZeroMQ ``XPUB``/``XSUB`` proxy. Workers connect by address (``tcp://`` or
+  ``ipc://``), so it is also native under ``--workers``. Same brokerless election. Needs ``pyzmq``.
+
+All three share the :class:`Backplane` interface, so the relay code above them is identical.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import struct
+import threading
+from typing import AsyncIterator
+
+_ID_LEN = 16  # per-instance sender id, prefixed to every frame so a backplane can skip its own messages
+_CLOSE = object()  # sentinel pushed on close() to unblock messages()
+
+
+class Backplane:
+    """A cross-process bytes pub/sub. Subclasses implement the transport; the framing + self-filtering
+    and the `messages()` iterator are shared. The sender id is set at construction (so it survives being
+    pickled to a child); the asyncio plumbing is created in :meth:`start`, inside the worker's loop."""
+
+    def __init__(self) -> None:
+        self._id = os.urandom(_ID_LEN)
+        self._inbox: asyncio.Queue | None = None
+        self._closed = False
+
+    async def start(self) -> None:
+        """Set up the transport and begin receiving. Call once, inside the running event loop."""
+        self._inbox = asyncio.Queue()
+        await self._start()
+
+    async def _start(self) -> None:  # pragma: no cover - overridden
+        raise NotImplementedError
+
+    async def publish(self, data: bytes) -> None:  # pragma: no cover - overridden
+        """Broadcast `data` to every other process on the bus."""
+        raise NotImplementedError
+
+    async def messages(self) -> AsyncIterator[bytes]:
+        """Yield frames published by other processes (never this one), until :meth:`close`."""
+        assert self._inbox is not None, "start() the backplane first"
+        while not self._closed:
+            item = await self._inbox.get()
+            if item is _CLOSE:
+                break
+            yield item
+
+    async def close(self) -> None:
+        self._closed = True
+        if self._inbox is not None:
+            self._inbox.put_nowait(_CLOSE)
+
+    # --- helpers for subclasses ---
+    def _frame(self, data: bytes) -> bytes:
+        return self._id + data
+
+    def _deliver(self, framed: bytes) -> None:
+        """Hand a raw framed message to `messages()`, unless it's malformed or our own echo."""
+        if self._inbox is None or len(framed) < _ID_LEN or framed[:_ID_LEN] == self._id:
+            return
+        self._inbox.put_nowait(framed[_ID_LEN:])
+
+
+class ZmqBackplane(Backplane):
+    """ZeroMQ ``XPUB``/``XSUB`` pub/sub. Native under ``uvicorn``/``gunicorn --workers`` (connect by
+    address). Brokerless: the first process to bind `front`/`back` runs the proxy in a daemon thread, the
+    rest connect. ``runs_proxy`` says which won. Defaults bind loopback TCP; pass ``ipc://`` paths to keep
+    it off the network."""
+
+    def __init__(self, front: str = "tcp://127.0.0.1:5599", back: str = "tcp://127.0.0.1:5600") -> None:
+        super().__init__()
+        self._front, self._back = front, back
+        self._pub = self._sub = None
+        self._task: asyncio.Task | None = None
+        self.runs_proxy = False
+
+    def _elect_proxy(self) -> bool:
+        import zmq
+
+        ctx = zmq.Context.instance()
+        xsub, xpub = ctx.socket(zmq.XSUB), ctx.socket(zmq.XPUB)
+        try:
+            xsub.bind(self._front)
+            xpub.bind(self._back)
+        except zmq.ZMQError:
+            xsub.close()
+            xpub.close()
+            return False
+        threading.Thread(target=lambda: zmq.proxy(xsub, xpub), daemon=True).start()
+        return True
+
+    async def _start(self) -> None:
+        import zmq
+        import zmq.asyncio
+
+        self.runs_proxy = self._elect_proxy()
+        ctx = zmq.asyncio.Context.instance()
+        self._pub = ctx.socket(zmq.PUB)
+        self._pub.connect(self._front)
+        self._sub = ctx.socket(zmq.SUB)
+        self._sub.connect(self._back)
+        self._sub.setsockopt(zmq.SUBSCRIBE, b"")
+        await asyncio.sleep(0.15)  # let the SUB finish connecting before any publish (ZMQ slow joiner)
+        self._task = asyncio.create_task(self._read())
+
+    async def _read(self) -> None:
+        try:
+            while not self._closed:
+                self._deliver(await self._sub.recv())
+        except asyncio.CancelledError:
+            pass
+
+    async def publish(self, data: bytes) -> None:
+        await self._pub.send(self._frame(data))
+
+    async def close(self) -> None:
+        await super().close()
+        if self._task:
+            self._task.cancel()
+        if self._pub:
+            self._pub.close()
+        if self._sub:
+            self._sub.close()
+
+
+class UnixSocketBackplane(Backplane):
+    """A Unix-domain-socket reflector. Native under ``uvicorn``/``gunicorn --workers`` (connect by path).
+    Brokerless: the first worker to bind `path` runs the reflector (re-broadcasts every frame to all
+    connections), the rest connect; everyone — the binder included — connects a client. ``runs_broker``
+    says which bound. Frames are length-prefixed."""
+
+    def __init__(self, path: str = "/tmp/transports-backplane.sock") -> None:
+        super().__init__()
+        self._path = path
+        self._server: asyncio.AbstractServer | None = None
+        self._peers: set[asyncio.StreamWriter] = set()  # reflector side
+        self._writer: asyncio.StreamWriter | None = None  # client side
+        self._task: asyncio.Task | None = None
+        self._lock_fd: int | None = None
+        self.runs_broker = False
+
+    async def _reflect(self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+        self._peers.add(writer)
+        try:
+            while True:
+                hdr = await reader.readexactly(4)
+                (n,) = struct.unpack(">I", hdr)
+                frame = hdr + await reader.readexactly(n)
+                for w in list(self._peers):
+                    w.write(frame)
+        except (asyncio.IncompleteReadError, ConnectionError):
+            pass
+        finally:
+            self._peers.discard(writer)
+            writer.close()
+
+    async def _start(self) -> None:
+        self.runs_broker = await self._elect()
+        reader, self._writer = await self._connect()  # everyone, the binder included, connects a client
+        self._task = asyncio.create_task(self._read(reader))
+
+    async def _elect(self) -> bool:
+        """Elect exactly one broker via an flock — atomic and race-free. (Bind can't elect: asyncio's
+        start_unix_server auto-unlinks an existing socket, so every binder would 'win'.) The lock holder
+        binds the socket, which auto-clears any stale one left by a prior run; everyone else connects."""
+        import fcntl
+
+        self._lock_fd = os.open(self._path + ".lock", os.O_CREAT | os.O_RDWR, 0o600)
+        try:
+            fcntl.flock(self._lock_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except OSError:
+            return False  # another process holds the broker lock
+        self._server = await asyncio.start_unix_server(self._reflect, path=self._path)
+        return True
+
+    async def _connect(self) -> tuple[asyncio.StreamReader, asyncio.StreamWriter]:
+        for _ in range(150):  # wait for the elected broker's socket to come up
+            try:
+                return await asyncio.open_unix_connection(path=self._path)
+            except OSError:
+                await asyncio.sleep(0.02)
+        raise OSError(f"could not connect to backplane at {self._path}")
+
+    async def _read(self, reader: asyncio.StreamReader) -> None:
+        try:
+            while not self._closed:
+                hdr = await reader.readexactly(4)
+                (n,) = struct.unpack(">I", hdr)
+                self._deliver(await reader.readexactly(n))
+        except (asyncio.IncompleteReadError, ConnectionError, asyncio.CancelledError):
+            pass
+
+    async def publish(self, data: bytes) -> None:
+        frame = self._frame(data)
+        self._writer.write(struct.pack(">I", len(frame)) + frame)
+        await self._writer.drain()
+
+    async def close(self) -> None:
+        await super().close()
+        if self._task:
+            self._task.cancel()
+        if self._writer:
+            self._writer.close()
+        if self._server:
+            self._server.close()
+        if self._lock_fd is not None:
+            os.close(self._lock_fd)  # releases the broker flock
+
+
+def _queue_broker(inbox, outs) -> None:
+    """Reflector process for :class:`QueueBackplane`: fan every frame to all worker queues (a backplane
+    drops its own by sender id)."""
+    while True:
+        framed = inbox.get()
+        if framed is None:
+            return
+        for q in outs:
+            q.put(framed)
+
+
+class QueueBackplane(Backplane):
+    """``multiprocessing`` queues. For a parent that spawns its own workers (or a ``gunicorn --preload``
+    fork): build the bus with :meth:`bus` in the parent and hand each worker its handle. Blocking
+    ``Queue.get`` is awaited in a thread, so it composes with asyncio. Not address-based — for
+    ``uvicorn --workers`` use :class:`ZmqBackplane` or :class:`UnixSocketBackplane`."""
+
+    def __init__(self, inbox, outbox) -> None:
+        super().__init__()
+        self._in = inbox  # shared: worker -> broker
+        self._out = outbox  # per-worker: broker -> this worker
+        self._task: asyncio.Task | None = None
+
+    @classmethod
+    def bus(cls, n: int):
+        """Create a broker process + `n` worker handles. Returns ``(broker_process, [handles])``; pass one
+        handle to each worker you spawn, and ``broker.terminate()`` on shutdown."""
+        import multiprocessing as mp
+
+        inbox = mp.Queue()
+        outs = [mp.Queue() for _ in range(n)]
+        proc = mp.Process(target=_queue_broker, args=(inbox, outs), daemon=True)
+        proc.start()
+        return proc, [cls(inbox, outs[i]) for i in range(n)]
+
+    async def _start(self) -> None:
+        self._loop = asyncio.get_running_loop()
+        self._task = asyncio.create_task(self._read())
+
+    async def _read(self) -> None:
+        try:
+            while not self._closed:
+                framed = await self._loop.run_in_executor(None, self._out.get)
+                if framed is None:
+                    break
+                self._deliver(framed)
+        except asyncio.CancelledError:
+            pass
+
+    async def publish(self, data: bytes) -> None:
+        self._in.put(self._frame(data))
+
+    async def close(self) -> None:
+        await super().close()
+        self._out.put(None)  # unblock the executor get
+        if self._task:
+            self._task.cancel()

--- a/transports/hub.py
+++ b/transports/hub.py
@@ -275,6 +275,18 @@ class Hub:
         if fan:
             self._shared_outbox.append((sid, fan))
 
+    def apply_shared(self, sid: int, patch: dict, origin: Any) -> None:
+        """Merge a shared-model write that happened on another worker (delivered over a backplane), and
+        queue the resulting authoritative fan for this worker's subscribers on the next `flush`. Do not
+        re-publish — the originating worker already broadcast it. When the model's `MergeStrategy` is a
+        CRDT this is convergent: applying the same set of writes in any order yields the same value, so
+        concurrent edits from clients on different workers reconcile identically everywhere."""
+        if self._shared.get(sid) is None:
+            return
+        fan = self._write_shared(sid, patch, origin)
+        if fan:
+            self._shared_outbox.append((sid, fan))
+
     def close(self, conn: Any) -> None:
         self._conn_key.pop(conn, None)
         self._codecs.pop(conn, None)

--- a/transports/hub.py
+++ b/transports/hub.py
@@ -47,6 +47,14 @@ class MergeStrategy:
     def merge(self, current: Any, patch: dict, origin: Any) -> Any:  # pragma: no cover - interface
         raise NotImplementedError
 
+    def state(self) -> dict:
+        """The strategy's own metadata (e.g. a CRDT clock), JSON-serializable, so a model's full state can
+        be transferred to a joining worker or persisted by the user. Stateless strategies return ``{}``."""
+        return {}
+
+    def restore(self, state: dict) -> None:
+        """Adopt metadata produced by :meth:`state` (catch-up or durable restore). Default: ignore."""
+
 
 class LastWriteWins(MergeStrategy):
     """Apply each write in arrival order (today's `Store` semantics). Order-dependent."""
@@ -96,6 +104,12 @@ class LwwMapCrdt(MergeStrategy):
                 mp = new.get("Map")
         return new
 
+    def state(self) -> dict:
+        return {"clock": {k: list(v) for k, v in self._clock.items()}}
+
+    def restore(self, state: dict) -> None:
+        self._clock = {k: tuple(v) for k, v in state.get("clock", {}).items()}
+
 
 class DeepLwwCrdt(MergeStrategy):
     """Field-granular conflict-free LWW — an independent last-writer-wins register at **every** map path,
@@ -132,16 +146,25 @@ class DeepLwwCrdt(MergeStrategy):
             new = json.loads(_apply(json.dumps(new), json.dumps({"rev": rev, "ops": [op]})))
         return new
 
+    def state(self) -> dict:
+        return {"clock": [[list(k), list(v)] for k, v in self._clock.items()]}
+
+    def restore(self, state: dict) -> None:
+        self._clock = {tuple(k): tuple(v) for k, v in state.get("clock", [])}
+
 
 class _Shared:
     """Authoritative state for a shared data structure."""
 
-    def __init__(self, type_name: str, value: dict, merge: MergeStrategy) -> None:
+    def __init__(self, type_name: str, value: dict, merge: MergeStrategy, *, replay: bool = False, rev: int = 0, log_cap: int = 512) -> None:
         self.type_name = type_name
         self.value = value
-        self.rev = 0
+        self.rev = rev
         self.merge = merge
         self.subs: Dict[Any, str] = {}  # tenant key -> mode
+        self.replay = replay
+        self.log: List[tuple] = []  # bounded [(rev, patch)] for delta catch-up when replay=True
+        self.log_cap = log_cap
 
 
 class Hub:
@@ -161,6 +184,7 @@ class Hub:
         self._conn_key: Dict[Any, Any] = {}
         self._codecs: Dict[Any, str] = {}
         self._shared_outbox: List[tuple] = []  # (sid, fan_patch) from host-side writes
+        self._on_shared_write: Optional[Callable] = None
 
     def tenant(self, key: Any) -> Session:
         """Get (or create) the `Session` holding a tenant's private models."""
@@ -169,12 +193,24 @@ class Hub:
             sess = self._tenants[key] = Session()
         return sess
 
-    def share(self, model_or_value: Any, type_name: Optional[str] = None, *, merge: Any = LastWriteWins) -> int:
+    def share(
+        self,
+        model_or_value: Any,
+        type_name: Optional[str] = None,
+        *,
+        merge: Any = LastWriteWins,
+        replay: bool = False,
+        rev: int = 0,
+        merge_state: Optional[dict] = None,
+    ) -> int:
         """Register a shared data structure; returns its shared id.
 
         Pass a model instance (pydantic/dataclass/msgspec) to capture its value and type name, or a
-        core `Value` dict together with `type_name`. `merge` is a `MergeStrategy` subclass (each
-        shared model gets its own instance) or an instance to reuse.
+        core `Value` dict together with `type_name`. `merge` is a `MergeStrategy` subclass (each shared
+        model gets its own instance) or an instance to reuse. ``replay=True`` keeps a bounded patch log
+        so a joining worker can catch up by delta (see :meth:`since_shared`) instead of a full snapshot.
+        To **restore** a model from a durable checkpoint on startup, pass ``rev`` and ``merge_state``
+        (from a prior :meth:`snapshot_shared`) alongside the saved value.
         """
         if type_name is None:
             type_name = type(model_or_value).__name__
@@ -182,9 +218,11 @@ class Hub:
         else:
             value = model_or_value
         strategy = merge() if isinstance(merge, type) else merge
+        if merge_state is not None:
+            strategy.restore(merge_state)
         sid = SHARED_ID_BASE + self._next_shared
         self._next_shared += 1
-        self._shared[sid] = _Shared(type_name, value, strategy)
+        self._shared[sid] = _Shared(type_name, value, strategy, replay=replay, rev=rev)
         return sid
 
     def subscribe(self, tenant_key: Any, sid: int, mode: str = READ) -> None:
@@ -287,6 +325,56 @@ class Hub:
         if fan:
             self._shared_outbox.append((sid, fan))
 
+    def on_shared_write(self, callback: Optional[Callable]) -> None:
+        """Register a callback fired after each authoritative shared write, with
+        ``(sid, type_name, value, rev, patch, merge_state)``. transports stores nothing durably; persist
+        these (the value+rev+merge_state, or append the patch) to make a model survive a full-cluster
+        restart, and restore with ``share(value=…, rev=…, merge_state=…)``. Gate on a single writer (e.g.
+        the relay's leader) if you don't want every worker persisting the same change."""
+        self._on_shared_write = callback
+
+    def snapshot_shared(self, sid: int) -> dict:
+        """The full transferable/persistable state of a shared model: ``value``, ``rev`` and the merge
+        clock (``merge_state``). Used by the relay to catch up a joining worker, and by users to
+        checkpoint for durability."""
+        sh = self._shared[sid]
+        return {"type_name": sh.type_name, "value": sh.value, "rev": sh.rev, "merge_state": sh.merge.state()}
+
+    def since_shared(self, sid: int, rev: int) -> Optional[List[dict]]:
+        """Patches after `rev` for a delta catch-up, or ``None`` if `rev` is outside the kept log (the
+        caller should fall back to a snapshot). Requires ``share(replay=True)``."""
+        sh = self._shared.get(sid)
+        if sh is None or not sh.replay:
+            return None
+        if rev >= sh.rev:
+            return []
+        if not sh.log or sh.log[0][0] > rev + 1:
+            return None  # the needed delta has scrolled out of the bounded log
+        return [p for r, p in sh.log if r > rev]
+
+    def apply_snapshot_shared(self, sid: int, value: dict, rev: int, merge_state: Optional[dict]) -> None:
+        """Adopt a peer's snapshot of a shared model: set value/rev and restore the merge clock, so later
+        merges respect the transferred causal stamps."""
+        sh = self._shared.get(sid)
+        if sh is None:
+            return
+        sh.value = value
+        sh.rev = max(sh.rev, rev)
+        sh.merge.restore(merge_state or {})
+
+    def apply_delta_shared(self, sid: int, patches: List[dict], rev: int, merge_state: Optional[dict]) -> None:
+        """Catch up by applying replay patches onto the current (restored) value, then restoring the merge
+        clock — cheaper than a snapshot when a recent checkpoint is held."""
+        sh = self._shared.get(sid)
+        if sh is None:
+            return
+        v = sh.value
+        for patch in patches:
+            v = json.loads(_apply(json.dumps(v), json.dumps(patch)))
+        sh.value = v
+        sh.rev = max(sh.rev, rev)
+        sh.merge.restore(merge_state or {})
+
     def close(self, conn: Any) -> None:
         self._conn_key.pop(conn, None)
         self._codecs.pop(conn, None)
@@ -301,6 +389,13 @@ class Hub:
         sh.value = new
         sh.rev += 1
         fan["rev"] = sh.rev
+        if sh.replay:
+            sh.log.append((sh.rev, fan))
+            if len(sh.log) > sh.log_cap:
+                del sh.log[: len(sh.log) - sh.log_cap]
+        if self._on_shared_write is not None:
+            # durability seam: the user persists this so the model survives a full-cluster restart.
+            self._on_shared_write(sid, sh.type_name, sh.value, sh.rev, fan, sh.merge.state())
         return fan
 
     def _fanout(self, sid: int, fan: dict) -> Dict[Any, List[Wire]]:

--- a/transports/hub.py
+++ b/transports/hub.py
@@ -340,17 +340,17 @@ class Hub:
         sh = self._shared[sid]
         return {"type_name": sh.type_name, "value": sh.value, "rev": sh.rev, "merge_state": sh.merge.state()}
 
-    def since_shared(self, sid: int, rev: int) -> Optional[List[dict]]:
-        """Patches after `rev` for a delta catch-up, or ``None`` if `rev` is outside the kept log (the
-        caller should fall back to a snapshot). Requires ``share(replay=True)``."""
+    def since_shared(self, sid: int, since_rev: int) -> Optional[List[dict]]:
+        """Patches after `since_rev` for a delta catch-up, or ``None`` if it is outside the kept log (the
+        caller should fall back to a snapshot). Requires ``share(replay=True)``. Mirrors `Session.since`."""
         sh = self._shared.get(sid)
         if sh is None or not sh.replay:
             return None
-        if rev >= sh.rev:
+        if since_rev >= sh.rev:
             return []
-        if not sh.log or sh.log[0][0] > rev + 1:
+        if not sh.log or sh.log[0][0] > since_rev + 1:
             return None  # the needed delta has scrolled out of the bounded log
-        return [p for r, p in sh.log if r > rev]
+        return [p for r, p in sh.log if r > since_rev]
 
     def apply_snapshot_shared(self, sid: int, value: dict, rev: int, merge_state: Optional[dict]) -> None:
         """Adopt a peer's snapshot of a shared model: set value/rev and restore the merge clock, so later

--- a/transports/relay.py
+++ b/transports/relay.py
@@ -1,0 +1,88 @@
+"""Cluster a :class:`~transports.Hub` across worker processes with a :class:`~transports.Backplane`.
+
+`uvicorn --workers N` spreads the connection I/O across cores, but each worker then has its own in-memory
+hub. :class:`RelayBroadcaster` bridges a local hub to a backplane so the cluster serves the *same* shared
+models. It satisfies the same broadcaster contract as `Hub`/`Server` (``open``/``recv``/``flush``/
+``close`` + ``default_codec``), so ``ws_endpoint(relay)`` and ``autosync(relay)`` work unchanged.
+
+- A **local** write to a shared model is applied + fanned to this worker's clients (by the hub) **and**
+  published to the backplane as ``{sid, patch, origin}``.
+- A write from **another** worker is merged in through the model's `MergeStrategy` and fanned to this
+  worker's clients on the next flush.
+
+Because the merge is a CRDT (e.g. :class:`~transports.DeepLwwCrdt`), concurrent writes from clients on
+different workers **converge**: every worker applies the same set of ``(patch, origin)`` writes, and the
+stamp on each write — not its arrival order — decides the outcome, so all replicas reach one value.
+"""
+
+import asyncio
+import json
+from typing import Any, Dict, List, Optional
+
+from . import protocol
+from .backplane import Backplane
+from .hub import SHARED_ID_BASE, Hub
+from .server import Wire
+from .transports import diff as _diff
+
+
+class RelayBroadcaster:
+    """Make a `Hub` part of a multi-worker cluster over a `Backplane`. Use it wherever a `Hub`/`Server`
+    goes: ``ws_endpoint(relay)`` for connections, ``autosync(relay)`` to drain. Call :meth:`start` once
+    (it starts the backplane + the consumer) and :meth:`stop` on shutdown."""
+
+    def __init__(self, hub: Hub, backplane: Backplane) -> None:
+        self.hub = hub
+        self.backplane = backplane
+        self.default_codec = hub.default_codec
+        self._task: Optional[asyncio.Task] = None
+
+    async def start(self) -> None:
+        await self.backplane.start()
+        self._task = asyncio.create_task(self._consume())
+
+    async def stop(self) -> None:
+        if self._task:
+            self._task.cancel()
+        await self.backplane.close()
+
+    async def _consume(self) -> None:
+        """Apply writes arriving from other workers; their fans go out on the next `flush`/`autosync`."""
+        try:
+            async for raw in self.backplane.messages():
+                m = json.loads(raw)
+                self.hub.apply_shared(m["sid"], m["patch"], m["origin"])
+        except asyncio.CancelledError:
+            pass
+
+    # --- broadcaster contract: delegate to the hub; recv also publishes shared writes to the cluster ---
+    def open(self, conn: Any, codec: Optional[str] = None, since: Optional[Dict[int, int]] = None) -> List[Wire]:
+        return self.hub.open(conn, codec, since)
+
+    def recv(self, conn: Any, data: Wire) -> Dict[Any, List[Wire]]:
+        out = self.hub.recv(conn, data)  # apply + fan to this worker's clients
+        msg = protocol.decode(data, self.hub._codecs.get(conn))
+        if msg.get("t") == "patch" and msg.get("id", 0) >= SHARED_ID_BASE:
+            origin = self.hub._conn_key.get(conn)
+            payload = json.dumps({"sid": msg["id"], "patch": msg["patch"], "origin": origin}).encode()
+            asyncio.create_task(self.backplane.publish(payload))  # broadcast the raw write to the others
+        return out
+
+    async def write_shared(self, sid: int, value: Any) -> None:
+        """Write to a shared model from the host side (e.g. a ticker) and propagate it to the cluster:
+        apply locally (fanned to this worker's clients on the next flush) and publish the patch so every
+        other worker applies it too. `value` is a core `Value` dict (or a model to convert upstream)."""
+        sh = self.hub._shared.get(sid)
+        if sh is None:
+            return
+        patch = json.loads(_diff(json.dumps(sh.value), json.dumps(value)))
+        if not patch.get("ops"):
+            return
+        self.hub.apply_shared(sid, patch, origin="<host>")
+        await self.backplane.publish(json.dumps({"sid": sid, "patch": patch, "origin": "<host>"}).encode())
+
+    def flush(self) -> Dict[Any, List[Wire]]:
+        return self.hub.flush()
+
+    def close(self, conn: Any) -> None:
+        self.hub.close(conn)

--- a/transports/relay.py
+++ b/transports/relay.py
@@ -5,18 +5,29 @@ hub. :class:`RelayBroadcaster` bridges a local hub to a backplane so the cluster
 models. It satisfies the same broadcaster contract as `Hub`/`Server` (``open``/``recv``/``flush``/
 ``close`` + ``default_codec``), so ``ws_endpoint(relay)`` and ``autosync(relay)`` work unchanged.
 
-- A **local** write to a shared model is applied + fanned to this worker's clients (by the hub) **and**
-  published to the backplane as ``{sid, patch, origin}``.
+- A **local** write to a shared model is applied + fanned to this worker's clients **and** published to
+  the backplane.
 - A write from **another** worker is merged in through the model's `MergeStrategy` and fanned to this
-  worker's clients on the next flush.
+  worker's clients. Because the merge is a CRDT, concurrent writes from clients on different workers
+  **converge**.
 
-Because the merge is a CRDT (e.g. :class:`~transports.DeepLwwCrdt`), concurrent writes from clients on
-different workers **converge**: every worker applies the same set of ``(patch, origin)`` writes, and the
-stamp on each write — not its arrival order — decides the outcome, so all replicas reach one value.
+**Joining late.** When a worker starts it issues a *request-for-state* on the backplane and a peer
+answers — either a full **snapshot** (value + rev + the merge clock) or, when the model is shared with
+``replay=True`` and the joiner already holds a recent checkpoint, a **delta** of patches since that rev
+(``resync`` vs ``replay``, chosen by what the joiner reports it ``have``s). Live writes that arrive while
+catching up are buffered and applied afterward (idempotent under the CRDT). :meth:`start` blocks until
+catch-up settles, so the worker only serves clients once consistent.
+
+**Durability.** transports stores nothing durably. Register :meth:`Hub.on_shared_write` to persist each
+authoritative change to *your* store, and restore with ``Hub.share(value=…, rev=…, merge_state=…)`` on
+startup. Then: a 1+ worker failure is covered by the surviving replicas + a rejoining worker's catch-up;
+a full-cluster failure is covered by your checkpoint. Gate persistence on :attr:`is_leader` for a single
+writer.
 """
 
 import asyncio
 import json
+import os
 from typing import Any, Dict, List, Optional
 
 from . import protocol
@@ -29,31 +40,110 @@ from .transports import diff as _diff
 class RelayBroadcaster:
     """Make a `Hub` part of a multi-worker cluster over a `Backplane`. Use it wherever a `Hub`/`Server`
     goes: ``ws_endpoint(relay)`` for connections, ``autosync(relay)`` to drain. Call :meth:`start` once
-    (it starts the backplane + the consumer) and :meth:`stop` on shutdown."""
+    (it starts the backplane, the consumer, and a catch-up) and :meth:`stop` on shutdown."""
 
     def __init__(self, hub: Hub, backplane: Backplane) -> None:
         self.hub = hub
         self.backplane = backplane
         self.default_codec = hub.default_codec
+        self._id = os.urandom(8).hex()
         self._task: Optional[asyncio.Task] = None
+        self._catching_up = False
+        self._buffer: List[tuple] = []
+        self._caught: set = set()
 
-    async def start(self) -> None:
+    @property
+    def is_leader(self) -> bool:
+        """True on the one worker that runs the backplane broker/proxy (a natural single writer for
+        durability). Always False for `QueueBackplane` (no election) — coordinate persistence yourself."""
+        return bool(getattr(self.backplane, "runs_proxy", getattr(self.backplane, "runs_broker", False)))
+
+    async def start(self, catch_up_timeout: float = 1.5) -> None:
         await self.backplane.start()
         self._task = asyncio.create_task(self._consume())
+        await self._catch_up(catch_up_timeout)
 
     async def stop(self) -> None:
         if self._task:
             self._task.cancel()
         await self.backplane.close()
 
+    async def _catch_up(self, timeout: float) -> None:
+        """Ask peers for the current state of our shared models; adopt the first answer per model. Buffer
+        live writes meanwhile and apply them after, so nothing is lost in the join window."""
+        sids = list(self.hub._shared)
+        if not sids:
+            return
+        self._catching_up, self._buffer, self._caught = True, [], set()
+        have = {str(sid): self.hub._shared[sid].rev for sid in sids}
+        await self.backplane.publish(json.dumps({"t": "req", "frm": self._id, "have": have}).encode())
+        loop = asyncio.get_running_loop()
+        t0 = loop.time()
+        while len(self._caught) < len(sids) and loop.time() - t0 < timeout:
+            await asyncio.sleep(0.05)
+        self._catching_up = False
+        for sid, patch, origin in self._buffer:
+            self.hub.apply_shared(sid, patch, origin)
+        self._buffer = []
+
     async def _consume(self) -> None:
-        """Apply writes arriving from other workers; their fans go out on the next `flush`/`autosync`."""
         try:
             async for raw in self.backplane.messages():
                 m = json.loads(raw)
-                self.hub.apply_shared(m["sid"], m["patch"], m["origin"])
+                t = m.get("t", "w")
+                if t == "w":
+                    if self._catching_up:
+                        self._buffer.append((m["sid"], m["patch"], m["origin"]))
+                    else:
+                        self.hub.apply_shared(m["sid"], m["patch"], m["origin"])
+                elif t == "req":
+                    await self._respond(m)
+                elif t == "resp" and m.get("to") == self._id:
+                    self._apply_resp(m)
         except asyncio.CancelledError:
             pass
+
+    async def _respond(self, m: dict) -> None:
+        """Answer a peer's request-for-state, per shared model: a delta when the model keeps a replay log
+        and the peer's `have` rev is still in it, else a full snapshot."""
+        if m.get("frm") == self._id:
+            return
+        have = m.get("have", {})
+        for sid in list(self.hub._shared):
+            want = have.get(str(sid), 0)
+            snap = self.hub.snapshot_shared(sid)
+            delta = self.hub.since_shared(sid, want) if want > 0 else None
+            if delta is not None:
+                resp = {
+                    "t": "resp",
+                    "to": m["frm"],
+                    "sid": sid,
+                    "kind": "delta",
+                    "patches": delta,
+                    "rev": snap["rev"],
+                    "merge_state": snap["merge_state"],
+                }
+            else:
+                resp = {
+                    "t": "resp",
+                    "to": m["frm"],
+                    "sid": sid,
+                    "kind": "snap",
+                    "value": snap["value"],
+                    "rev": snap["rev"],
+                    "merge_state": snap["merge_state"],
+                }
+            await self.backplane.publish(json.dumps(resp).encode())
+
+    def _apply_resp(self, m: dict) -> None:
+        sid = m["sid"]
+        if sid in self._caught:
+            return  # already caught up for this model from an earlier responder
+        if m["kind"] == "snap":
+            self.hub.apply_snapshot_shared(sid, m["value"], m["rev"], m.get("merge_state"))
+        else:
+            self.hub.apply_delta_shared(sid, m["patches"], m["rev"], m.get("merge_state"))
+        self._caught.add(sid)
 
     # --- broadcaster contract: delegate to the hub; recv also publishes shared writes to the cluster ---
     def open(self, conn: Any, codec: Optional[str] = None, since: Optional[Dict[int, int]] = None) -> List[Wire]:
@@ -64,14 +154,13 @@ class RelayBroadcaster:
         msg = protocol.decode(data, self.hub._codecs.get(conn))
         if msg.get("t") == "patch" and msg.get("id", 0) >= SHARED_ID_BASE:
             origin = self.hub._conn_key.get(conn)
-            payload = json.dumps({"sid": msg["id"], "patch": msg["patch"], "origin": origin}).encode()
+            payload = json.dumps({"t": "w", "sid": msg["id"], "patch": msg["patch"], "origin": origin}).encode()
             asyncio.create_task(self.backplane.publish(payload))  # broadcast the raw write to the others
         return out
 
     async def write_shared(self, sid: int, value: Any) -> None:
         """Write to a shared model from the host side (e.g. a ticker) and propagate it to the cluster:
-        apply locally (fanned to this worker's clients on the next flush) and publish the patch so every
-        other worker applies it too. `value` is a core `Value` dict (or a model to convert upstream)."""
+        apply locally (fanned on the next flush) and publish so every other worker applies it too."""
         sh = self.hub._shared.get(sid)
         if sh is None:
             return
@@ -79,7 +168,7 @@ class RelayBroadcaster:
         if not patch.get("ops"):
             return
         self.hub.apply_shared(sid, patch, origin="<host>")
-        await self.backplane.publish(json.dumps({"sid": sid, "patch": patch, "origin": "<host>"}).encode())
+        await self.backplane.publish(json.dumps({"t": "w", "sid": sid, "patch": patch, "origin": "<host>"}).encode())
 
     def flush(self) -> Dict[Any, List[Wire]]:
         return self.hub.flush()

--- a/transports/relay.py
+++ b/transports/relay.py
@@ -66,7 +66,7 @@ class RelayBroadcaster:
     async def stop(self) -> None:
         if self._task:
             self._task.cancel()
-        await self.backplane.close()
+        await self.backplane.stop()
 
     async def _catch_up(self, timeout: float) -> None:
         """Ask peers for the current state of our shared models; adopt the first answer per model. Buffer
@@ -158,9 +158,10 @@ class RelayBroadcaster:
             asyncio.create_task(self.backplane.publish(payload))  # broadcast the raw write to the others
         return out
 
-    async def write_shared(self, sid: int, value: Any) -> None:
+    async def set_shared(self, sid: int, value: Any) -> None:
         """Write to a shared model from the host side (e.g. a ticker) and propagate it to the cluster:
-        apply locally (fanned on the next flush) and publish so every other worker applies it too."""
+        apply locally (fanned on the next flush) and publish so every other worker applies it too. The
+        cluster-aware counterpart of `Hub.set_shared`."""
         sh = self.hub._shared.get(sid)
         if sh is None:
             return

--- a/transports/tests/test_backplane.py
+++ b/transports/tests/test_backplane.py
@@ -1,0 +1,91 @@
+"""Each backplane must relay frames between separate processes: 3 peers beacon their id and every peer
+should receive the other two (never its own). Exercises QueueBackplane, UnixSocketBackplane, and
+ZmqBackplane across real processes."""
+
+import asyncio
+import multiprocessing as mp
+import os
+import random
+import tempfile
+from functools import partial
+
+import pytest
+
+from transports.backplane import QueueBackplane, UnixSocketBackplane, ZmqBackplane
+
+
+def _peer(make, my_id, result_q, secs=1.5):
+    """Child process: start a backplane (from a factory, or a passed-in handle), beacon `my_id`, collect
+    what others send, report the set seen."""
+
+    async def go():
+        bp = make() if callable(make) else make
+        await bp.start()
+        seen: set[str] = set()
+
+        async def collect():
+            async for m in bp.messages():
+                seen.add(m.decode())
+
+        loop = asyncio.get_running_loop()
+        ct = asyncio.create_task(collect())
+        end = loop.time() + secs
+        while loop.time() < end:
+            await bp.publish(my_id.encode())
+            await asyncio.sleep(0.1)
+        await asyncio.sleep(0.25)
+        ct.cancel()
+        await bp.close()
+        result_q.put((my_id, sorted(seen)))
+
+    asyncio.run(go())
+
+
+def _run(makes):
+    """Spawn one peer per factory/handle; return {id: set(seen)} after all report."""
+    result_q = mp.Queue()
+    ids = [str(i) for i in range(len(makes))]
+    procs = [mp.Process(target=_peer, args=(makes[i], ids[i], result_q)) for i in range(len(makes))]
+    for p in procs:
+        p.start()
+    results = {}
+    for _ in procs:
+        mid, seen = result_q.get(timeout=20)
+        results[mid] = set(seen)
+    for p in procs:
+        p.join(timeout=5)
+    return results
+
+
+def _assert_full_mesh(results, ids):
+    for i in ids:
+        assert results[i] == (set(ids) - {i}), f"peer {i} saw {results[i]}, expected the other peers"
+
+
+def test_queue_backplane_relays_across_processes():
+    broker, handles = QueueBackplane.bus(3)
+    try:
+        results = _run(handles)
+    finally:
+        broker.terminate()
+    _assert_full_mesh(results, ["0", "1", "2"])
+
+
+def test_unix_socket_backplane_relays_across_processes():
+    path = os.path.join(tempfile.gettempdir(), f"tbp-{os.getpid()}-{random.randint(0, 9999)}.sock")
+    try:
+        results = _run([partial(UnixSocketBackplane, path)] * 3)
+    finally:
+        try:
+            os.unlink(path)
+        except OSError:
+            pass
+    _assert_full_mesh(results, ["0", "1", "2"])
+
+
+def test_zmq_backplane_relays_across_processes():
+    pytest.importorskip("zmq")
+    base = random.randint(20000, 60000)
+    front, back = f"tcp://127.0.0.1:{base}", f"tcp://127.0.0.1:{base + 1}"
+    results = _run([partial(ZmqBackplane, front, back)] * 3)
+    _assert_full_mesh(results, ["0", "1", "2"])

--- a/transports/tests/test_backplane.py
+++ b/transports/tests/test_backplane.py
@@ -6,12 +6,15 @@ import asyncio
 import multiprocessing as mp
 import os
 import random
+import sys
 import tempfile
 from functools import partial
 
 import pytest
 
 from transports.backplane import QueueBackplane, UnixSocketBackplane, ZmqBackplane
+
+posix_only = pytest.mark.skipif(sys.platform == "win32", reason="Unix domain sockets are POSIX-only")
 
 
 def _peer(make, my_id, result_q, secs=1.5):
@@ -71,6 +74,7 @@ def test_queue_backplane_relays_across_processes():
     _assert_full_mesh(results, ["0", "1", "2"])
 
 
+@posix_only
 def test_unix_socket_backplane_relays_across_processes():
     path = os.path.join(tempfile.gettempdir(), f"tbp-{os.getpid()}-{random.randint(0, 9999)}.sock")
     try:

--- a/transports/tests/test_backplane.py
+++ b/transports/tests/test_backplane.py
@@ -38,7 +38,7 @@ def _peer(make, my_id, result_q, secs=1.5):
             await asyncio.sleep(0.1)
         await asyncio.sleep(0.25)
         ct.cancel()
-        await bp.close()
+        await bp.stop()
         result_q.put((my_id, sorted(seen)))
 
     asyncio.run(go())

--- a/transports/tests/test_relay.py
+++ b/transports/tests/test_relay.py
@@ -74,3 +74,156 @@ def test_concurrent_cross_worker_edits_converge():
     m = results[0]["Map"]
     assert m["a"] == {"Int": 0} and m["b"] == {"Int": 1}, "distinct-field edits should both survive"
     assert m["x"] == {"Int": 11}, "the conflicting field should resolve to the (1,'t1') winner on both"
+
+
+# --- catch-up + durability (relay logic over a tiny in-process bus) ---
+
+from transports import DeepLwwCrdt, Hub, RelayBroadcaster  # noqa: E402
+from transports.backplane import Backplane  # noqa: E402
+
+
+class _Bus:
+    def __init__(self):
+        self.peers = []
+
+
+class MemBackplane(Backplane):
+    """An in-process backplane for testing relay logic without sockets — peers share a `_Bus`."""
+
+    def __init__(self, bus):
+        super().__init__()
+        self.bus = bus
+
+    async def _start(self):
+        self.bus.peers.append(self)
+
+    async def publish(self, data):
+        framed = self._frame(data)
+        for p in self.bus.peers:
+            if p is not self:
+                p._deliver(framed)
+
+
+def test_late_joiner_catches_up_and_inherits_the_clock():
+    async def go():
+        bus = _Bus()
+        hub_a = Hub(key=lambda c: c)
+        sid = hub_a.share({"Map": {}}, "Doc", merge=DeepLwwCrdt)
+        relay_a = RelayBroadcaster(hub_a, MemBackplane(bus))
+        await relay_a.start(catch_up_timeout=0.2)  # first worker, no peer
+        hub_a.apply_shared(sid, _patch(1, ("a", 0), ("x", 10)), "ca")  # A's client edits
+
+        hub_b = Hub(key=lambda c: c)  # B joins late, empty
+        hub_b.share({"Map": {}}, "Doc", merge=DeepLwwCrdt)
+        relay_b = RelayBroadcaster(hub_b, MemBackplane(bus))
+        await relay_b.start(catch_up_timeout=1.0)  # request-for-state -> A answers -> adopt
+
+        assert hub_b._shared[sid].value == hub_a._shared[sid].value, "joiner did not catch up"
+        # the merge clock came across too: a stale write (lower stamp) to a caught-up field is dropped
+        hub_b.apply_shared(sid, _patch(1, ("x", 999)), "aa")  # (1,'aa') < (1,'ca')
+        assert hub_b._shared[sid].value["Map"]["x"] == {"Int": 10}, "stale write should be dropped"
+
+    asyncio.run(go())
+
+
+def test_durable_restore_recovers_value_rev_and_clock():
+    store = {}
+    hub = Hub(key=lambda c: c)
+    sid = hub.share({"Map": {}}, "Doc", merge=DeepLwwCrdt)
+    hub.on_shared_write(lambda s, tn, value, rev, patch, ms: store.update(value=value, rev=rev, ms=ms))
+    hub.apply_shared(sid, _patch(1, ("a", 1), ("x", 5)), "ca")
+    hub.apply_shared(sid, _patch(2, ("x", 7)), "cb")  # x -> 7, stamp (2,'cb')
+
+    # "full-cluster restart": a fresh hub restores from the user's store
+    hub2 = Hub(key=lambda c: c)
+    sid2 = hub2.share(store["value"], "Doc", merge=DeepLwwCrdt, rev=store["rev"], merge_state=store["ms"])
+    assert hub2._shared[sid2].value == hub._shared[sid].value
+    assert hub2._shared[sid2].rev == hub._shared[sid].rev
+    hub2.apply_shared(sid2, _patch(1, ("x", 999)), "aa")  # (1,'aa') < (2,'cb') -> dropped (clock restored)
+    assert hub2._shared[sid2].value["Map"]["x"] == {"Int": 7}
+
+
+def test_since_shared_returns_delta_or_none():
+    hub = Hub(key=lambda c: c)
+    sid = hub.share({"Map": {}}, "Doc", merge=DeepLwwCrdt, replay=True)
+    for r in range(1, 4):
+        hub.apply_shared(sid, _patch(r, (f"k{r}", r)), f"c{r}")
+    assert hub.since_shared(sid, 3) == []  # already current
+    assert len(hub.since_shared(sid, 1)) == 2  # patches for rev 2 and 3
+    no_replay = hub.share({"Map": {}}, "Doc2", merge=DeepLwwCrdt)  # replay=False
+    assert hub.since_shared(no_replay, 0) is None
+
+
+def test_late_joiner_with_checkpoint_catches_up_by_delta():
+    async def go():
+        bus = _Bus()
+        hub_a = Hub(key=lambda c: c)
+        sid = hub_a.share({"Map": {}}, "Doc", merge=DeepLwwCrdt, replay=True)
+        relay_a = RelayBroadcaster(hub_a, MemBackplane(bus))
+        await relay_a.start(catch_up_timeout=0.2)
+        hub_a.apply_shared(sid, _patch(1, ("a", 1)), "ca")
+        hub_a.apply_shared(sid, _patch(2, ("b", 2)), "cb")
+
+        # B restored a stale checkpoint at rev 1 (value has only "a") -> should be sent the rev-2 delta
+        hub_b = Hub(key=lambda c: c)
+        hub_b.share({"Map": {"a": {"Int": 1}}}, "Doc", merge=DeepLwwCrdt, replay=True, rev=1)
+        relay_b = RelayBroadcaster(hub_b, MemBackplane(bus))
+        await relay_b.start(catch_up_timeout=1.0)
+
+        assert hub_b._shared[sid].value == hub_a._shared[sid].value, "delta catch-up did not converge"
+
+    asyncio.run(go())
+
+
+def _alive_worker(path, result_q):
+    async def go():
+        from transports import DeepLwwCrdt, Hub, RelayBroadcaster, UnixSocketBackplane
+
+        hub = Hub(key=lambda c: c)
+        sid = hub.share({"Map": {}}, "Doc", merge=DeepLwwCrdt)
+        relay = RelayBroadcaster(hub, UnixSocketBackplane(path))
+        await relay.start(catch_up_timeout=0.3)
+        hub.apply_shared(sid, _patch(1, ("a", 0), ("x", 10)), "ca")
+        await asyncio.sleep(3.0)  # stay up to answer the joiner's request
+        result_q.put(("a", hub._shared[sid].value))
+        await relay.stop()
+
+    asyncio.run(go())
+
+
+def _joiner_worker(path, result_q):
+    async def go():
+        await asyncio.sleep(1.2)  # join after the first worker has edited
+        from transports import DeepLwwCrdt, Hub, RelayBroadcaster, UnixSocketBackplane
+
+        hub = Hub(key=lambda c: c)
+        hub.share({"Map": {}}, "Doc", merge=DeepLwwCrdt)
+        relay = RelayBroadcaster(hub, UnixSocketBackplane(path))
+        await relay.start(catch_up_timeout=2.0)  # request-for-state over the real backplane
+        result_q.put(("b", hub._shared[next(iter(hub._shared))].value))
+        await relay.stop()
+
+    asyncio.run(go())
+
+
+def test_cross_process_late_joiner_catches_up_over_a_real_backplane():
+    path = os.path.join(tempfile.gettempdir(), f"tbp-join-{os.getpid()}-{random.randint(0, 9999)}.sock")
+    result_q = mp.Queue()
+    procs = [
+        mp.Process(target=_alive_worker, args=(path, result_q)),
+        mp.Process(target=_joiner_worker, args=(path, result_q)),
+    ]
+    for p in procs:
+        p.start()
+    res = {}
+    for _ in procs:
+        k, v = result_q.get(timeout=20)
+        res[k] = v
+    for p in procs:
+        p.join(timeout=5)
+    try:
+        os.unlink(path)
+    except OSError:
+        pass
+    assert res["b"] == res["a"], "a worker joining late did not catch up over the backplane"
+    assert res["b"]["Map"]["x"] == {"Int": 10}

--- a/transports/tests/test_relay.py
+++ b/transports/tests/test_relay.py
@@ -48,7 +48,7 @@ def _worker(path, idx, patch, result_q):
             await bp.publish(payload)
             await asyncio.sleep(0.3)
         ct.cancel()
-        await bp.close()
+        await bp.stop()
         result_q.put((idx, hub._shared[sid].value))
 
     asyncio.run(go())

--- a/transports/tests/test_relay.py
+++ b/transports/tests/test_relay.py
@@ -1,0 +1,76 @@
+"""Cross-worker convergence: a client on one worker and a client on another edit the same shared model
+concurrently, the writes propagate over a backplane, and both workers' replicas converge — distinct
+fields both survive, a conflicting field resolves to the same winner everywhere. This is the CRDT path
+(`DeepLwwCrdt`) running across processes through `RelayBroadcaster`'s publish/apply."""
+
+import asyncio
+import json
+import multiprocessing as mp
+import os
+import random
+import tempfile
+
+
+def _patch(rev, *kv):
+    return {"rev": rev, "ops": [{"Set": {"path": [{"Key": k}], "value": {"Int": v}}} for k, v in kv]}
+
+
+def _worker(path, idx, patch, result_q):
+    """One worker: host the shared model, apply its own write + publish it, apply the other's, report the
+    converged value. Re-publishes a few times so the result doesn't depend on connect timing (re-applying
+    a write is idempotent under the CRDT — same stamp)."""
+
+    async def go():
+        from transports import DeepLwwCrdt, Hub, UnixSocketBackplane
+
+        hub = Hub(key=lambda c: c)
+        sid = hub.share({"Map": {}}, "Doc", merge=DeepLwwCrdt)  # first share on each -> same sid
+        hub.subscribe(f"t{idx}", sid, "write")
+        bp = UnixSocketBackplane(path)
+        await bp.start()
+        origin = f"t{idx}"
+
+        async def consume():
+            async for raw in bp.messages():
+                m = json.loads(raw)
+                hub.apply_shared(m["sid"], m["patch"], m["origin"])
+
+        ct = asyncio.create_task(consume())
+        hub.apply_shared(sid, patch, origin)  # this worker's own client edit
+        payload = json.dumps({"sid": sid, "patch": patch, "origin": origin}).encode()
+        await asyncio.sleep(0.3)  # let both backplanes connect
+        for _ in range(4):
+            await bp.publish(payload)
+            await asyncio.sleep(0.3)
+        ct.cancel()
+        await bp.close()
+        result_q.put((idx, hub._shared[sid].value))
+
+    asyncio.run(go())
+
+
+def test_concurrent_cross_worker_edits_converge():
+    path = os.path.join(tempfile.gettempdir(), f"tbp-relay-{os.getpid()}-{random.randint(0, 9999)}.sock")
+    patches = {
+        0: _patch(1, ("a", 0), ("x", 10)),  # worker 0: unique key "a" + conflicting "x"
+        1: _patch(1, ("b", 1), ("x", 11)),  # worker 1: unique key "b" + conflicting "x"
+    }
+    result_q = mp.Queue()
+    procs = [mp.Process(target=_worker, args=(path, i, patches[i], result_q)) for i in (0, 1)]
+    for p in procs:
+        p.start()
+    results = {}
+    for _ in procs:
+        idx, value = result_q.get(timeout=20)
+        results[idx] = value
+    for p in procs:
+        p.join(timeout=5)
+    try:
+        os.unlink(path)
+    except OSError:
+        pass
+
+    assert results[0] == results[1], "replicas did not converge"
+    m = results[0]["Map"]
+    assert m["a"] == {"Int": 0} and m["b"] == {"Int": 1}, "distinct-field edits should both survive"
+    assert m["x"] == {"Int": 11}, "the conflicting field should resolve to the (1,'t1') winner on both"

--- a/transports/tests/test_relay.py
+++ b/transports/tests/test_relay.py
@@ -8,7 +8,12 @@ import json
 import multiprocessing as mp
 import os
 import random
+import sys
 import tempfile
+
+import pytest
+
+posix_only = pytest.mark.skipif(sys.platform == "win32", reason="Unix domain sockets are POSIX-only")
 
 
 def _patch(rev, *kv):
@@ -49,6 +54,7 @@ def _worker(path, idx, patch, result_q):
     asyncio.run(go())
 
 
+@posix_only
 def test_concurrent_cross_worker_edits_converge():
     path = os.path.join(tempfile.gettempdir(), f"tbp-relay-{os.getpid()}-{random.randint(0, 9999)}.sock")
     patches = {
@@ -206,6 +212,7 @@ def _joiner_worker(path, result_q):
     asyncio.run(go())
 
 
+@posix_only
 def test_cross_process_late_joiner_catches_up_over_a_real_backplane():
     path = os.path.join(tempfile.gettempdir(), f"tbp-join-{os.getpid()}-{random.randint(0, 9999)}.sock")
     result_q = mp.Queue()


### PR DESCRIPTION
The multi-worker half of the connection-scaling work: spread the fan-out across cores, keep every worker's model consistent, and give users the seams to survive failures — without transports storing anything durably.

## 1. `Backplane` — a bytes pub/sub
`publish()` → every *other* worker; `messages()` → what they publish (self-filtered).

| impl | mechanism | native `uvicorn --workers`? |
|---|---|---|
| `QueueBackplane` | multiprocessing queues | no — fork / `gunicorn --preload` |
| `UnixSocketBackplane` | UDS reflector (connect by path) | **yes** |
| `ZmqBackplane` | ZeroMQ XPUB/XSUB (connect by address) | **yes** |

Address-based ones are **brokerless** — workers self-elect (UDS via `flock`, ZMQ via bind), no extra process.

## 2. `RelayBroadcaster` — cluster a `Hub`
Drop-in for `ws_endpoint(relay)` + `autosync(relay)`. Local write → fanned to this worker's clients **and** published; remote write → merged via the model's `MergeStrategy` → fanned locally; `set_shared()` for a host-side ticker.

## 3. Concurrent cross-worker edits converge (CRDT)
The CRDT stamps each write `(patch_rev, origin)` — **intrinsic, not arrival order** — so all workers reach one value. Verified cross-process: clients on two workers edit the same `DeepLwwCrdt` model → distinct fields survive, a conflicting field resolves to the same winner on both.

## 4. Joining late — request-for-state, **resync vs replay** (configurable)
A worker that starts mid-flight issues a request-for-state; a peer answers with either a **snapshot** (value + rev + **merge clock**) or, when the model is `share(replay=True)` and the joiner holds a recent checkpoint, a **delta** of patches since that rev — chosen by what the joiner reports it `have`s. Live writes during the window are buffered + applied after (idempotent). `start()` blocks until consistent, so a worker serves clients only once caught up. The merge clock travels too (`MergeStrategy.state()/restore()`), so a joiner inherits causal stamps — a later stale write to a caught-up field is correctly dropped.

## 5. Durability seams (transports stores nothing)
- `Hub.on_shared_write(cb)` → `(sid, type_name, value, rev, patch, merge_state)` on each authoritative write — **persist to your store**;
- `Hub.share(value=, rev=, merge_state=)` → **restore** from a checkpoint on startup;
- `RelayBroadcaster.is_leader` → gate single-writer persistence.

So **1+ worker failure** is covered by surviving replicas + a rejoiner's catch-up; a **full-cluster failure** by the user's checkpoint. The durability *policy* (snapshot every N writes? append patches? which store?) is the user's — we provide the hooks.

## Verified
- 3-process full-mesh per backplane; both address-based classes under real `uvicorn --workers 3`.
- Cross-worker convergence + a **cross-process late-joiner catching up over a real backplane**.
- Resync, replay/`since_shared`, durable restore (value + rev + clock), clock-inheritance-drops-stale.
- **Scaling**: one worker pegs a single core (p95 5.7 s at 8 k conns); four spread across cores (2.8 s).
- 92 tests green; `zmq` is an optional lazy import.

## Still open (smaller)
- **Sticky routing**: a client reconnecting to a *different* worker sees that replica's `rev` sequence — sticky sessions or rev reconciliation for production.
- Leaderless durability gating for `QueueBackplane` (no election) — coordinate externally.

