### PR TITLE
transports: client durability — reconnect + configurable authoritative source

### DIFF
--- a/js/src/ts/client.ts
+++ b/js/src/ts/client.ts
@@ -120,6 +120,63 @@ export class Client {
     return ws;
   }
 
+  /** Connect and mirror, **reconnecting** whenever the socket drops — so the client survives a server
+   * restart or a refresh. `authority` decides reconciliation on each (re)connect:
+   *
+   * - `"server"` (default): the server is canonical; the client adopts its state (resuming via `?since=`
+   *   when it can, else a fresh snapshot) — the "refetch on refresh" behavior.
+   * - `"client"`: the client is canonical; after the server's snapshot it pushes its last-known state
+   *   back as an edit, rectifying a server that came back stale/empty (merges under a CRDT, else
+   *   overwrites).
+   *
+   * `onMessage` fires after each applied frame (e.g. to re-render). Returns `{ stop() }`.
+   */
+  run(
+    url: string,
+    opts: {
+      authority?: "server" | "client";
+      retry?: number;
+      onMessage?: () => void;
+    } = {},
+  ): { stop: () => void } {
+    const { authority = "server", retry = 1000, onMessage } = opts;
+    let stopped = false;
+    const loop = () => {
+      if (stopped) return;
+      const pre = authority === "client" ? new Map(this.values) : null;
+      const pushed = new Set<number>();
+      const ws = this.connect(url); // reuses connect(): adds the recv listener + ?since= resume
+      ws.addEventListener("message", () => {
+        onMessage?.();
+        if (pre) {
+          // rectify: once the server has (re)snapshotted a model, push our copy back to it
+          for (const id of this.values.keys()) {
+            if (!pushed.has(id) && pre.has(id)) {
+              ws.send(this.edit(id, pre.get(id)));
+              pushed.add(id);
+            }
+          }
+        }
+      });
+      ws.addEventListener("close", () => {
+        if (!stopped) setTimeout(loop, retry);
+      });
+      ws.addEventListener("error", () => {
+        try {
+          ws.close();
+        } catch {
+          /* already closing */
+        }
+      });
+    };
+    loop();
+    return {
+      stop() {
+        stopped = true;
+      },
+    };
+  }
+
   /** Mirror a server over Server-Sent Events (receive-only, JSON). Returns the `EventSource`. */
   connectSSE(url: string): EventSource {
     const es = new EventSource(url);

--- a/transports/client.py
+++ b/transports/client.py
@@ -66,21 +66,57 @@ class Client:
         patch = json.loads(_diff(json.dumps(self._values[mid]), json.dumps(new_value)))
         return protocol.encode(protocol.patch_msg(mid, patch), self._codec)
 
-    async def connect(self, url: str) -> None:
-        """Connect to a transports server and mirror it until the connection closes.
-
-        Appends ``?codec=`` for the client's codec, and — if this client already mirrors models (a
-        reconnect) — ``?since=`` with its last-seen rev per model, so the server replays only the delta.
-        """
-        import websockets
-
+    def _connect_url(self, url: str) -> str:
+        """``url`` + ``?codec=``, plus ``?since=`` (last-seen rev per model) when this client already
+        mirrors models, so a reconnect resumes from the delta instead of re-sending each whole model."""
         sep = "&" if "?" in url else "?"
         params = f"codec={self._codec}"
-        if self._rev:  # resume: bring this mirror up to date from where it left off
+        if self._rev:
             params += "&since=" + urllib.parse.quote(json.dumps(self._rev))
-        async with websockets.connect(f"{url}{sep}{params}") as ws:
+        return f"{url}{sep}{params}"
+
+    async def connect(self, url: str) -> None:
+        """Connect to a transports server and mirror it until the connection closes (one connection)."""
+        import websockets
+
+        async with websockets.connect(self._connect_url(url)) as ws:
             async for frame in ws:
                 self.recv(frame)
+
+    async def run(self, url: str, *, authority: str = "server", retry: float = 1.0) -> None:
+        """Connect and mirror, **reconnecting** whenever the connection drops — so the client survives a
+        server restart or a network blip. ``authority`` decides reconciliation on each (re)connect:
+
+        - ``"server"`` (default): the server is canonical; the client adopts its state (resuming from
+          ``?since=`` when it can, else a fresh snapshot). This is the "refetch on refresh" behavior.
+        - ``"client"``: the client is canonical; after the server's snapshot it **pushes its last-known
+          state back** as an edit, so a server that came back stale or empty is rectified from the client.
+          With a CRDT model the push merges (newer stamps win); otherwise it overwrites.
+
+        Runs until cancelled. The choice of *where the authoritative state lives* is yours — pair this
+        with the server-side durability hooks (`Hub.on_shared_write`) as your use case needs.
+        """
+        import asyncio
+
+        import websockets
+
+        if authority not in ("server", "client"):
+            raise ValueError(f"authority must be 'server' or 'client', not {authority!r}")
+        while True:
+            pre = dict(self._values) if authority == "client" else None
+            pushed: set = set()
+            try:
+                async with websockets.connect(self._connect_url(url)) as ws:
+                    async for frame in ws:
+                        self.recv(frame)
+                        if pre:  # rectify: once the server has (re)snapshotted a model, push our copy back
+                            for mid in list(self._values):
+                                if mid not in pushed and mid in pre:
+                                    await ws.send(self.edit(mid, pre[mid]))
+                                    pushed.add(mid)
+            except (websockets.ConnectionClosed, OSError):
+                pass  # dropped — fall through to retry
+            await asyncio.sleep(retry)
 
     async def connect_sse(self, url: str) -> None:
         """Mirror a transports server over Server-Sent Events (receive-only) until the stream closes.

--- a/transports/tests/test_client_durability.py
+++ b/transports/tests/test_client_durability.py
@@ -1,0 +1,102 @@
+"""Client durability: the client reconnects across a server restart, and `authority` decides who wins —
+the **server** (client adopts the restarted server's state: refetch-on-reconnect) or the **client** (it
+pushes its last-known state back, rectifying a server that came back stale/empty)."""
+
+import asyncio
+import socket
+
+from transports import Client, DeepLwwCrdt, Hub
+from transports.hub import WRITE
+
+
+def _free_port() -> int:
+    s = socket.socket()
+    s.bind(("127.0.0.1", 0))
+    port = s.getsockname()[1]
+    s.close()
+    return port
+
+
+async def _serve(hub: Hub, sid: int, port: int, stop: asyncio.Event) -> None:
+    import websockets
+
+    async def handler(ws):
+        hub.subscribe(ws, sid, WRITE)
+        for m in hub.open(ws):
+            await ws.send(m)
+        try:
+            async for frame in ws:
+                for conn, msgs in hub.recv(ws, frame).items():
+                    for msg in msgs:
+                        await conn.send(msg)
+        except Exception:
+            pass
+        finally:
+            hub.close(ws)
+
+    async with websockets.serve(handler, "127.0.0.1", port):
+        await stop.wait()
+
+
+async def _until(cond, timeout=6.0) -> bool:
+    loop = asyncio.get_running_loop()
+    t0 = loop.time()
+    while loop.time() - t0 < timeout:
+        if cond():
+            return True
+        await asyncio.sleep(0.05)
+    return False
+
+
+def test_server_authoritative_reconnect_adopts_restarted_state():
+    async def go():
+        port = _free_port()
+        hub1 = Hub(key=lambda ws: ws)
+        sid = hub1.share({"Map": {"a": {"Int": 1}}}, "Doc", merge=DeepLwwCrdt)
+        stop1 = asyncio.Event()
+        s1 = asyncio.create_task(_serve(hub1, sid, port, stop1))
+        client = Client()
+        runner = asyncio.create_task(client.run(f"ws://127.0.0.1:{port}/", authority="server", retry=0.2))
+
+        assert await _until(lambda: sid in client.ids() and client.value(sid) == {"Map": {"a": {"Int": 1}}})
+        stop1.set()
+        await s1
+
+        # the server comes back with a DIFFERENT state; a server-authoritative client adopts it
+        hub2 = Hub(key=lambda ws: ws)
+        hub2.share({"Map": {"b": {"Int": 2}}}, "Doc", merge=DeepLwwCrdt)
+        stop2 = asyncio.Event()
+        s2 = asyncio.create_task(_serve(hub2, sid, port, stop2))
+        assert await _until(lambda: client.value(sid) == {"Map": {"b": {"Int": 2}}}), "did not adopt server"
+        runner.cancel()
+        stop2.set()
+        await s2
+
+    asyncio.run(go())
+
+
+def test_client_authoritative_reconnect_rectifies_a_stale_server():
+    async def go():
+        port = _free_port()
+        hub1 = Hub(key=lambda ws: ws)
+        sid = hub1.share({"Map": {"a": {"Int": 1}}}, "Doc", merge=DeepLwwCrdt)
+        stop1 = asyncio.Event()
+        s1 = asyncio.create_task(_serve(hub1, sid, port, stop1))
+        client = Client()
+        runner = asyncio.create_task(client.run(f"ws://127.0.0.1:{port}/", authority="client", retry=0.2))
+
+        assert await _until(lambda: sid in client.ids() and client.value(sid) == {"Map": {"a": {"Int": 1}}})
+        stop1.set()
+        await s1
+
+        # the server comes back EMPTY (lost its state); a client-authoritative client pushes its copy back
+        hub2 = Hub(key=lambda ws: ws)
+        hub2.share({"Map": {}}, "Doc", merge=DeepLwwCrdt)
+        stop2 = asyncio.Event()
+        s2 = asyncio.create_task(_serve(hub2, sid, port, stop2))
+        assert await _until(lambda: hub2._shared[sid].value == {"Map": {"a": {"Int": 1}}}), "client did not rectify"
+        runner.cancel()
+        stop2.set()
+        await s2
+
+    asyncio.run(go())


### PR DESCRIPTION
A client should survive a server restart, a refresh, or a network blip — and apps differ on **who's canonical** when it comes back. `Client.run(url, authority=...)` (Python + JS) adds that.

## Reconnect
`run()` connects and mirrors, **reconnecting** whenever the socket drops (the one-shot `connect()` is unchanged). On reconnect it resumes via `?since=` when it can, else takes a fresh snapshot.

## Configurable authoritative source
- **`authority="server"`** (default) — the server is canonical; the client **adopts** the restarted server's state. This is the "refetch on refresh" behavior: a reload (or a reconnect that lands on any worker) shows the current authoritative state.
- **`authority="client"`** — the client is canonical; after the server's snapshot it **pushes its last-known state back** as an edit, rectifying a server that came back stale or empty. Under a CRDT model the push merges (newer stamps win); otherwise it overwrites.

So you decide where the authoritative state lives — pair this with the server-side durability hooks (`Hub.on_shared_write`, in #139). Some apps want the server as the source of truth; local-first apps want the client to push back for rectification.

## Verified
2 integration tests over a **restarting ws server**: server-auth adopts the new state, client-auth rectifies an emptied server. JS mirrors the API and bundles. 85 Python tests green.
