### PR TITLE
transports: leader election + singleton task (Election) + dedicated ZMQ broker

### DIFF
--- a/transports/__init__.py
+++ b/transports/__init__.py
@@ -1,9 +1,10 @@
 from . import protocol
 from ._bridge import from_value, schema_of, schema_to_ts, to_value
 from .anywidget import serve_anywidget
-from .backplane import Backplane, QueueBackplane, UnixSocketBackplane, ZmqBackplane
+from .backplane import Backplane, QueueBackplane, UnixSocketBackplane, ZmqBackplane, serve_zmq_broker
 from .client import Client
 from .comm import serve_comm
+from .election import Election
 from .hub import READ, WRITE, DeepLwwCrdt, Hub, LastWriteWins, LwwMapCrdt, MergeStrategy
 from .protocol import decode_as, encode_as, register_codec, registered_codecs, unregister_codec  # registry-aware wrappers
 from .relay import RelayBroadcaster
@@ -55,12 +56,14 @@ __all__ = [
     "ws_endpoint",
     "sse_endpoint",
     "serve_comm",
-    # cross-process backplane (multi-worker fan-out)
+    # cross-process backplane (multi-worker fan-out) + clustering
     "Backplane",
     "QueueBackplane",
     "UnixSocketBackplane",
     "ZmqBackplane",
+    "serve_zmq_broker",
     "RelayBroadcaster",
+    "Election",
     "serve_anywidget",
     "autosync",
     "sync",

--- a/transports/backplane.py
+++ b/transports/backplane.py
@@ -43,12 +43,11 @@ class Backplane:
 
     def __init__(self) -> None:
         self._id = os.urandom(_ID_LEN)
-        self._inbox: asyncio.Queue | None = None
+        self._subscribers: set = set()  # one asyncio.Queue per live messages() consumer
         self._closed = False
 
     async def start(self) -> None:
         """Set up the transport and begin receiving. Call once, inside the running event loop."""
-        self._inbox = asyncio.Queue()
         await self._start()
 
     async def _start(self) -> None:  # pragma: no cover - overridden
@@ -59,28 +58,36 @@ class Backplane:
         raise NotImplementedError
 
     async def messages(self) -> AsyncIterator[bytes]:
-        """Yield frames published by other processes (never this one), until :meth:`stop`."""
-        assert self._inbox is not None, "start() the backplane first"
-        while not self._closed:
-            item = await self._inbox.get()
-            if item is _CLOSE:
-                break
-            yield item
+        """Yield frames published by other processes (never this one), until :meth:`stop`. Each call is an
+        independent stream, so several consumers in one process (e.g. a relay and an election) each receive
+        every frame and filter for the message type they care about."""
+        q: asyncio.Queue = asyncio.Queue()
+        self._subscribers.add(q)
+        try:
+            while not self._closed:
+                item = await q.get()
+                if item is _CLOSE:
+                    break
+                yield item
+        finally:
+            self._subscribers.discard(q)
 
     async def stop(self) -> None:
         self._closed = True
-        if self._inbox is not None:
-            self._inbox.put_nowait(_CLOSE)
+        for q in list(self._subscribers):
+            q.put_nowait(_CLOSE)
 
     # --- helpers for subclasses ---
     def _frame(self, data: bytes) -> bytes:
         return self._id + data
 
     def _deliver(self, framed: bytes) -> None:
-        """Hand a raw framed message to `messages()`, unless it's malformed or our own echo."""
-        if self._inbox is None or len(framed) < _ID_LEN or framed[:_ID_LEN] == self._id:
+        """Fan a raw framed message to every live `messages()` consumer, unless malformed or our own echo."""
+        if len(framed) < _ID_LEN or framed[:_ID_LEN] == self._id:
             return
-        self._inbox.put_nowait(framed[_ID_LEN:])
+        payload = framed[_ID_LEN:]
+        for q in self._subscribers:
+            q.put_nowait(payload)
 
 
 class ZmqBackplane(Backplane):
@@ -288,3 +295,22 @@ class QueueBackplane(Backplane):
         self._out.put(None)  # unblock the executor get
         if self._task:
             self._task.cancel()
+
+
+def serve_zmq_broker(front: str = "tcp://127.0.0.1:5599", back: str = "tcp://127.0.0.1:5600") -> None:
+    """Run a standalone ZeroMQ XSUB/XPUB proxy — a **dedicated broker** for :class:`ZmqBackplane`. Run it
+    as a sidecar so the bus is not hosted inside a worker: each `ZmqBackplane`'s brokerless election then
+    yields to it (their bind fails, so they connect), removing the single point of failure where the worker
+    that won the election would take the whole bus down with it. Blocks. Run with
+    ``python -m transports.backplane [front] [back]``."""
+    import zmq
+
+    ctx = zmq.Context.instance()
+    xsub, xpub = ctx.socket(zmq.XSUB), ctx.socket(zmq.XPUB)
+    xsub.bind(front)
+    xpub.bind(back)
+    zmq.proxy(xsub, xpub)  # blocks forever
+
+
+if __name__ == "__main__":  # a dedicated ZMQ broker: `python -m transports.backplane [front] [back]`
+    serve_zmq_broker(*sys.argv[1:3])

--- a/transports/election.py
+++ b/transports/election.py
@@ -1,0 +1,102 @@
+"""Leader election + a singleton task across a cluster, over a `Backplane`.
+
+`uvicorn --workers N` (or any multi-process cluster) sometimes needs a job to run on **exactly one**
+worker — a ticker, a scheduler, a single writer — and to **fail over** if that worker dies. `Election`
+provides that over the same backplane the cluster already shares: each member beacons its id, and the
+member with the smallest id seen alive (within `timeout`) is the leader, so when the leader stops
+beaconing the next-smallest takes over within `timeout`. (This decouples "who runs the job" from "who
+runs the backplane broker" — unlike a backplane's own proxy election, it survives the broker moving, and
+pairs with a dedicated broker, `transports.backplane.serve_zmq_broker`, to remove the bus's single point
+of failure.)
+
+It is a lease over best-effort pub/sub, not consensus: during a failover two members may both consider
+themselves leader for up to `timeout`, so make the singleton task idempotent or tolerant of brief overlap.
+For a hard single-writer guarantee, back it with an external coordinator (etcd / ZooKeeper / Raft).
+"""
+
+import asyncio
+import json
+import os
+import time
+from typing import Awaitable, Callable, Optional
+
+from .backplane import Backplane
+
+
+class Election:
+    """Leader election over a `Backplane`. Read :attr:`is_leader`, or run a coroutine on exactly the leader
+    with :meth:`run_singleton`. Share the cluster's (multi-subscriber) backplane — election beacons are
+    tagged so they don't collide with other traffic. The backplane must already be ``start()``ed (the relay
+    or your app does that)."""
+
+    def __init__(self, backplane: Backplane, *, id: Optional[str] = None, interval: float = 1.0, timeout: float = 3.0) -> None:
+        self.backplane = backplane
+        self.id = id or os.urandom(8).hex()
+        self.interval = interval
+        self.timeout = timeout
+        self._seen: dict = {}  # peer id -> monotonic last-seen
+        self._tasks: list = []
+        self._singleton: Optional[asyncio.Task] = None
+        self._stopped = False
+
+    @property
+    def is_leader(self) -> bool:
+        """True when this member is running and no peer with a smaller id has beaconed within `timeout` —
+        i.e. it is the smallest live member. With no peers heard, a lone member leads itself; a stopped
+        member never leads."""
+        if self._stopped:
+            return False
+        now = time.monotonic()
+        return all(self.id <= pid for pid, seen in self._seen.items() if now - seen < self.timeout)
+
+    async def start(self) -> None:
+        """Begin beaconing + tracking peers (does not start a singleton task)."""
+        if not self._tasks:
+            self._tasks = [asyncio.create_task(self._beacon()), asyncio.create_task(self._listen())]
+
+    async def stop(self) -> None:
+        self._stopped = True
+        for t in self._tasks:
+            t.cancel()
+        if self._singleton:
+            self._singleton.cancel()
+            self._singleton = None
+
+    async def run_singleton(self, factory: Callable[[], Awaitable]) -> None:
+        """Run ``factory()`` (a coroutine function) on whichever member is the leader: (re)start it on
+        gaining leadership, cancel it on losing it. Runs until :meth:`stop`. Waits one beacon round first
+        so ids are exchanged before the first decision (reducing startup overlap)."""
+        await self.start()
+        await asyncio.sleep(self.interval)
+        try:
+            while not self._stopped:
+                if self.is_leader and self._singleton is None:
+                    self._singleton = asyncio.create_task(factory())
+                elif not self.is_leader and self._singleton is not None:
+                    self._singleton.cancel()
+                    self._singleton = None
+                await asyncio.sleep(self.interval / 2)
+        finally:
+            if self._singleton:
+                self._singleton.cancel()
+                self._singleton = None
+
+    async def _beacon(self) -> None:
+        try:
+            while not self._stopped:
+                await self.backplane.publish(json.dumps({"election": self.id}).encode())
+                await asyncio.sleep(self.interval)
+        except asyncio.CancelledError:
+            pass
+
+    async def _listen(self) -> None:
+        try:
+            async for raw in self.backplane.messages():
+                try:
+                    m = json.loads(raw)
+                except (ValueError, TypeError):
+                    continue
+                if isinstance(m, dict) and "election" in m:
+                    self._seen[m["election"]] = time.monotonic()
+        except asyncio.CancelledError:
+            pass

--- a/transports/tests/test_election.py
+++ b/transports/tests/test_election.py
@@ -1,0 +1,115 @@
+"""Leader election + singleton task over a backplane, and the backplane's multi-subscriber fan-out (so a
+relay and an election can share one bus). Uses a tiny in-process backplane to drive the logic
+deterministically."""
+
+import asyncio
+
+from transports import Election
+from transports.backplane import Backplane
+
+
+class _Bus:
+    def __init__(self):
+        self.peers = []
+
+
+class MemBackplane(Backplane):
+    """In-process backplane: peers share a `_Bus` and deliver to each other."""
+
+    def __init__(self, bus):
+        super().__init__()
+        self.bus = bus
+
+    async def _start(self):
+        self.bus.peers.append(self)
+
+    async def publish(self, data):
+        framed = self._frame(data)
+        for p in self.bus.peers:
+            if p is not self:
+                p._deliver(framed)
+
+
+def test_backplane_fans_to_multiple_subscribers():
+    async def go():
+        bus = _Bus()
+        a, b = MemBackplane(bus), MemBackplane(bus)
+        await a.start()
+        await b.start()
+        got1, got2 = [], []
+
+        async def consume(bp, out):
+            async for m in bp.messages():
+                out.append(m)
+
+        t1 = asyncio.create_task(consume(a, got1))
+        t2 = asyncio.create_task(consume(a, got2))  # second consumer on the SAME backplane
+        await asyncio.sleep(0.05)
+        await b.publish(b"hello")
+        await asyncio.sleep(0.1)
+        assert got1 == [b"hello"] and got2 == [b"hello"], (got1, got2)
+        t1.cancel()
+        t2.cancel()
+        await a.stop()
+        await b.stop()
+
+    asyncio.run(go())
+
+
+def test_smallest_id_leads_and_fails_over():
+    async def go():
+        bus = _Bus()
+        es = []
+        for i in ("a", "b", "c"):  # "a" < "b" < "c"
+            bp = MemBackplane(bus)
+            await bp.start()
+            e = Election(bp, id=i, interval=0.1, timeout=0.5)
+            await e.start()
+            es.append(e)
+        await asyncio.sleep(0.4)  # exchange beacons
+        assert [e.id for e in es if e.is_leader] == ["a"]
+
+        await es[0].stop()  # the leader dies
+        await asyncio.sleep(0.9)  # > timeout: its lease expires
+        assert [e.id for e in es if e.is_leader] == ["b"], "next-smallest should take over"
+
+        for e in es[1:]:
+            await e.stop()
+
+    asyncio.run(go())
+
+
+def test_run_singleton_runs_only_on_the_leader():
+    async def go():
+        bus = _Bus()
+        ran = {"a": 0, "b": 0}
+
+        def task_for(label):
+            async def task():
+                try:
+                    while True:
+                        ran[label] += 1
+                        await asyncio.sleep(0.05)
+                except asyncio.CancelledError:
+                    pass
+
+            return task
+
+        es, runners = [], []
+        for i in ("a", "b"):
+            bp = MemBackplane(bus)
+            await bp.start()
+            e = Election(bp, id=i, interval=0.1, timeout=0.5)
+            es.append(e)
+            runners.append(asyncio.create_task(e.run_singleton(task_for(i))))
+        await asyncio.sleep(0.4)  # let leadership settle
+        ran["a"] = ran["b"] = 0  # measure the steady state (a brief startup overlap is documented + expected)
+        await asyncio.sleep(0.5)
+        assert ran["a"] > 0 and ran["b"] == 0, ran  # only the leader runs the singleton
+
+        for e in es:
+            await e.stop()
+        for r in runners:
+            r.cancel()
+
+    asyncio.run(go())


### PR DESCRIPTION
The leader-election / singleton-task primitive (with a dedicated broker to kill the SPOF) raised in the cluster-example review.

## `Election` — run a job on exactly one worker, with failover
Leader election over a `Backplane`: each member beacons its id; the **smallest live id** (within `timeout`) is the leader, so when the leader stops beaconing the **next-smallest takes over within `timeout`**.

```python
election = Election(relay.backplane)            # share the cluster's bus
await election.run_singleton(ticker)            # runs ticker() on exactly the leader, fails over on death
# or just read election.is_leader
```

It's a **lease over best-effort pub/sub, not consensus** — during a failover two members may both lead for up to `timeout`, so make the task idempotent (or back it with etcd/Raft for a hard guarantee). It **decouples "who runs the job" from "who runs the broker"**, unlike a backplane's own proxy election.

## `serve_zmq_broker` — a dedicated broker (no SPOF)
The brokerless `ZmqBackplane` elects an in-worker proxy — fine for a demo, but that worker is a single point of failure for the whole bus. Run a standalone proxy instead:

```
python -m transports.backplane [front] [back]   # a dedicated XSUB/XPUB broker
```

Workers' election then yields to it (their bind fails → they connect), so no worker hosts the bus.

## Backplane is now multi-subscriber
Each `messages()` call is an independent stream, so a **relay and an election share one bus** (each filters by message type) — no second bus needed. Backward compatible (a single consumer still gets every frame).

## Verified
3 tests: multi-subscriber fan-out; smallest-id leads + fails over to the next when the leader dies; `run_singleton` runs only on the leader. 97 Python tests green.
