### PR TITLE
Reject invalid client edits instead of crashing the host

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@ JavaScript (wasm), so both sides use the same `Value`, diff, patch, and codec ma
 [![License](https://img.shields.io/github/license/1kbgz/transports)](https://github.com/1kbgz/transports)
 [![PyPI](https://img.shields.io/pypi/v/transports.svg)](https://pypi.python.org/pypi/transports)
 
-
 ```python
 import transports
 from pydantic import BaseModel

--- a/transports/hub.py
+++ b/transports/hub.py
@@ -282,7 +282,13 @@ class Hub:
             return {}
         authoritative = sess.submit(wire_id, msg["patch"])
         if authoritative is None:
-            return {}
+            # Rejected (invalid edit / malformed patch): revert just the proposer to the authoritative
+            # state so its UI self-corrects; the host never crashes and other tenants are untouched.
+            snap = sess.snapshot(wire_id)
+            if snap is None:
+                return {}
+            revert = protocol.snapshot_msg(wire_id, snap["type_name"], snap["rev"], snap["value"])
+            return {conn: [self._encode_for(conn, revert)]}
         relay = protocol.patch_msg(wire_id, authoritative)
         return {c: [self._encode_for(c, relay)] for c, k in self._conn_key.items() if k == key}
 

--- a/transports/server.py
+++ b/transports/server.py
@@ -83,7 +83,14 @@ class Server:
         if msg.get("t") == "patch":
             authoritative = self._session.submit(msg["id"], msg["patch"])
             if authoritative is None:
-                return {}
+                # Rejected (invalid edit, or a malformed patch): re-send the authoritative state to the
+                # proposer alone, so its optimistic UI reverts to the last good value. The server stays up
+                # and other connections are untouched — a round-trip validation failure self-corrects.
+                snap = self._session.snapshot(msg["id"])
+                if snap is None:
+                    return {}
+                revert = protocol.snapshot_msg(msg["id"], snap["type_name"], snap["rev"], snap["value"])
+                return {conn: [self._encode_for(conn, revert)]}
             relay = protocol.patch_msg(msg["id"], authoritative)
             return {c: [self._encode_for(c, relay)] for c in self._codecs}
         return {}

--- a/transports/session.py
+++ b/transports/session.py
@@ -16,7 +16,7 @@ from typing import Any, Callable, Dict, List, Optional, Set, Tuple
 from bigbrother import watch
 
 from ._bridge import _annotations, from_value, schema_of, to_value
-from .transports import Store as _CoreStore
+from .transports import Store as _CoreStore, apply as _apply
 
 
 class Session:
@@ -115,8 +115,14 @@ class Session:
         snap = self._store.snapshot(mid)
         if snap is None:
             return None
-        cur_rev = json.loads(snap)["rev"]
-        authoritative = {"rev": cur_rev + 1, "ops": patch.get("ops", [])}
+        parsed = json.loads(snap)
+        authoritative = {"rev": parsed["rev"] + 1, "ops": patch.get("ops", [])}
+        # Validate the *result* against the hosted model BEFORE committing, so an invalid edit (e.g. a
+        # non-numeric string into an int field) is rejected cleanly — never crashing the host, and never
+        # leaving the core value inconsistent with the model. A client edit is a proposal; the server may
+        # reject it (the caller then re-sends the authoritative state so the client's UI reverts).
+        if not self._validates(mid, parsed["value"], authoritative):
+            return None
         if not self._apply_authoritative(mid, authoritative):
             return None  # reject a malformed proposal (bad path/type/index) without crashing the host
         self._record(mid, authoritative)
@@ -140,13 +146,37 @@ class Session:
             return None  # the next needed patch was evicted — gap, can't replay
         return [patch for rev, patch in log if rev > since_rev]
 
+    def _validates(self, mid: int, current_value: dict, patch: dict) -> bool:
+        """True if applying ``patch`` to ``current_value`` yields a value the hosted model accepts.
+
+        Computed on a *copy* via the pure ``apply`` — so a rejected proposal never touches the store — then
+        round-tripped through the model bridge (which lets pydantic / msgspec validate and reject). A model
+        with no typed object hosted here (a plain mirror) can't be validated and is accepted; dataclasses,
+        which don't validate, accept per their own semantics."""
+        obj = self._models.get(mid)
+        if obj is None:
+            return True
+        try:
+            candidate = _apply(json.dumps(current_value), json.dumps(patch))
+        except ValueError:
+            return False  # the core rejected a malformed patch (bad path/type/index)
+        try:
+            from_value(json.loads(candidate), type(obj))
+        except Exception:
+            return False  # the result doesn't validate against the model (pydantic / msgspec / ...)
+        return True
+
     def _apply_authoritative(self, mid: int, patch: dict) -> bool:
         try:
             if not self._store.apply(mid, json.dumps(patch)):
                 return False
         except ValueError:
             return False  # the core rejected a malformed patch (bad path/type/index)
-        self._refresh_model(mid)
+        try:
+            self._refresh_model(mid)
+        except Exception:
+            return False  # never crash the host: a model that rejects the value (caught pre-commit by
+            # `_validates`, but belt-and-suspenders for any caller that didn't pre-validate)
         return True
 
     def _refresh_model(self, mid: int) -> None:

--- a/transports/tests/test_apply_safety.py
+++ b/transports/tests/test_apply_safety.py
@@ -1,3 +1,5 @@
+import json
+
 from pydantic import BaseModel
 
 import transports
@@ -5,6 +7,10 @@ import transports
 
 class M(BaseModel):
     x: int = 0
+
+
+class Device(BaseModel):
+    brightness: int = 60
 
 
 def test_submit_rejects_malformed_patch_without_crashing():
@@ -27,3 +33,42 @@ def test_submit_rejects_malformed_patch_without_crashing():
     auth = sess.submit(mid, good)
     assert auth is not None
     assert m.x == 7
+
+
+def test_submit_rejects_an_edit_the_model_cannot_validate():
+    """The reported crash: a non-numeric string edited into an int field raised pydantic ValidationError
+    from the model refresh and killed the connection. It must now be rejected, the model + core value
+    left untouched, and the host kept alive."""
+    d = Device()
+    sess = transports.Session()
+    mid = sess.host(d)
+    before = sess.value(mid)
+
+    bad = {"rev": 0, "ops": [{"Set": {"path": [{"Key": "brightness"}], "value": {"Str": ""}}}]}
+    assert sess.submit(mid, bad) is None  # rejected, not applied (no exception)
+    assert d.brightness == 60  # the hosted model is untouched
+    assert sess.value(mid) == before  # the core value is untouched — no partial commit
+
+    # the session still works: a valid edit goes through
+    good = {"rev": 0, "ops": [{"Set": {"path": [{"Key": "brightness"}], "value": {"Int": 80}}}]}
+    assert sess.submit(mid, good) is not None
+    assert d.brightness == 80
+
+
+def test_server_reverts_only_the_proposer_on_a_rejected_edit():
+    """A rejected edit makes the server re-send the authoritative snapshot to the *proposing* connection
+    (so its optimistic UI reverts to the last good value) and broadcast nothing to the others."""
+    sess = transports.Session()
+    mid = sess.host(Device(brightness=60))
+    server = transports.Server(sess)
+    proposer, other = object(), object()
+    server.open(proposer)  # registers each connection's codec (default JSON)
+    server.open(other)
+
+    edit = {"t": "patch", "id": mid, "patch": {"rev": 0, "ops": [{"Set": {"path": [{"Key": "brightness"}], "value": {"Str": ""}}}]}}
+    out = server.recv(proposer, transports.protocol.encode(json.dumps(edit), transports.protocol.JSON))
+
+    assert set(out) == {proposer}  # only the proposer is messaged — no broadcast of the bad edit
+    revert = transports.protocol.decode(out[proposer][0], transports.protocol.JSON)
+    assert revert["t"] == "snapshot"  # a fresh authoritative snapshot…
+    assert transports.from_value(revert["value"], Device).brightness == 60  # …restoring the good value


### PR DESCRIPTION
## The bug
A client `edit` is a *proposal* applied to a server-authoritative model. When the proposed value didn't validate against the hosted model — e.g. typing a letter into an `int` field sends `brightness=""` — `Session._apply_authoritative` committed the bad value to the core store and **then** raised pydantic's `ValidationError` from the model refresh. That escaped the websocket endpoint and **killed the connection** (and left the core value inconsistent with the model).

```
pydantic_core.ValidationError: 1 validation error for Device
brightness
  Input should be a valid integer, unable to parse string as an integer [input_value='', input_type=str]
```

## The fix — validate before commit, never crash, self-correct
- **`Session.submit` validates the *result* against the hosted model BEFORE committing** (new `_validates`), computed on a copy via the pure `apply`, so a rejected proposal never touches the store. pydantic / msgspec validation errors are caught; dataclasses (which don't validate) accept per their semantics; a plain mirror with no hosted object is accepted. `_apply_authoritative` also guards the refresh as belt-and-suspenders — the host can never crash on a bad value.
- **`Server.recv` / `Hub.recv`, on a rejected edit, re-send the authoritative snapshot to the *proposing* connection only** — so its optimistic UI reverts to the last good value — and broadcast nothing to others. A round-trip validation failure now **self-corrects**, protocol-compatible (no new message type, no client change).

## Verified
- New tests in `test_apply_safety.py`: an invalid edit is rejected with the model + core value untouched and the session still usable; the server reverts only the proposer. **Full suite: 99 pass.**
- End-to-end against the spaday omnibus form (the original repro): `brightness=""` → reverted to `60`, server stays up, valid edits still work, nothing logged.

## Follow-up (not in this PR)
Surfacing the validation *message* to the client (a toast / `wa-input` invalid state) — today the control silently reverts. That needs a small reject frame + a client/`connectStore` hook (or client-side validation from the schema). Happy to do it as a follow-up; this PR is the safety net (never crash, always consistent, auto-revert).

This advances the roadmap's *"Schema validation on the wire — reject malformed / invalid edits server-side"* and *"Error model"* items.