### PR TITLE
Canonicalize a client edit to the model's type (coercion fidelity)

### DIFF
--- a/transports/session.py
+++ b/transports/session.py
@@ -16,7 +16,7 @@ from typing import Any, Callable, Dict, List, Optional, Set, Tuple
 from bigbrother import watch
 
 from ._bridge import _annotations, from_value, schema_of, to_value
-from .transports import Store as _CoreStore, apply as _apply
+from .transports import Store as _CoreStore, apply as _apply, diff as _diff
 
 
 class Session:
@@ -116,15 +116,19 @@ class Session:
         if snap is None:
             return None
         parsed = json.loads(snap)
-        authoritative = {"rev": parsed["rev"] + 1, "ops": patch.get("ops", [])}
-        # Validate the *result* against the hosted model BEFORE committing, so an invalid edit (e.g. a
-        # non-numeric string into an int field) is rejected cleanly — never crashing the host, and never
-        # leaving the core value inconsistent with the model. A client edit is a proposal; the server may
-        # reject it (the caller then re-sends the authoritative state so the client's UI reverts).
-        if not self._validates(mid, parsed["value"], authoritative):
-            return None
+        cur = parsed["value"]
+        # Validate AND canonicalize the proposal through the hosted model (on a copy, so a bad edit never
+        # touches the store): pydantic/msgspec reject an invalid value, and a *coercible* one is normalized
+        # to its canonical typed form — e.g. a number control sends the string "80", and the stored value
+        # becomes the int 80, so the core value, the Python model, and every client agree. The authoritative
+        # patch is the diff to that canonical value (not the client's raw ops), keeping all three in sync.
+        canonical = self._canonical(mid, cur, patch.get("ops", []))
+        if canonical is None:
+            return None  # invalid / malformed — rejected (the caller re-sends state so the proposer reverts)
+        ops = json.loads(_diff(json.dumps(cur), json.dumps(canonical))).get("ops", [])
+        authoritative = {"rev": parsed["rev"] + 1, "ops": ops}
         if not self._apply_authoritative(mid, authoritative):
-            return None  # reject a malformed proposal (bad path/type/index) without crashing the host
+            return None
         self._record(mid, authoritative)
         return authoritative
 
@@ -146,25 +150,25 @@ class Session:
             return None  # the next needed patch was evicted — gap, can't replay
         return [patch for rev, patch in log if rev > since_rev]
 
-    def _validates(self, mid: int, current_value: dict, patch: dict) -> bool:
-        """True if applying ``patch`` to ``current_value`` yields a value the hosted model accepts.
+    def _canonical(self, mid: int, current_value: dict, ops: list) -> Optional[dict]:
+        """The proposal applied to ``current_value`` and normalized through the hosted model — its canonical
+        typed `Value` — or ``None`` if the core rejects the patch or the model rejects the value.
 
         Computed on a *copy* via the pure ``apply`` — so a rejected proposal never touches the store — then
-        round-tripped through the model bridge (which lets pydantic / msgspec validate and reject). A model
-        with no typed object hosted here (a plain mirror) can't be validated and is accepted; dataclasses,
-        which don't validate, accept per their own semantics."""
+        round-tripped through the model bridge: pydantic / msgspec validate (rejecting bad input) and coerce
+        (so ``"80"`` for an int field comes back as ``80``). A model with no typed object hosted here (a plain
+        mirror) returns the candidate unchanged; dataclasses accept per their own semantics."""
+        try:
+            candidate = json.loads(_apply(json.dumps(current_value), json.dumps({"rev": 0, "ops": ops})))
+        except ValueError:
+            return None  # the core rejected a malformed patch (bad path/type/index)
         obj = self._models.get(mid)
         if obj is None:
-            return True
+            return candidate  # untyped mirror — nothing to canonicalize against
         try:
-            candidate = _apply(json.dumps(current_value), json.dumps(patch))
-        except ValueError:
-            return False  # the core rejected a malformed patch (bad path/type/index)
-        try:
-            from_value(json.loads(candidate), type(obj))
+            return to_value(from_value(candidate, type(obj)))  # validate + coerce to the canonical typed value
         except Exception:
-            return False  # the result doesn't validate against the model (pydantic / msgspec / ...)
-        return True
+            return None  # the result doesn't validate against the model (pydantic / msgspec / ...)
 
     def _apply_authoritative(self, mid: int, patch: dict) -> bool:
         try:

--- a/transports/tests/test_apply_safety.py
+++ b/transports/tests/test_apply_safety.py
@@ -72,3 +72,21 @@ def test_server_reverts_only_the_proposer_on_a_rejected_edit():
     revert = transports.protocol.decode(out[proposer][0], transports.protocol.JSON)
     assert revert["t"] == "snapshot"  # a fresh authoritative snapshot…
     assert transports.from_value(revert["value"], Device).brightness == 60  # …restoring the good value
+
+
+def test_a_coercible_edit_is_canonicalized_to_the_models_type():
+    """A number control sends its value as a string; the stored value — and the broadcast patch — must be
+    the model's canonical type, so the core value never diverges from the validated model."""
+    d = Device()  # brightness: int = 60
+    sess = transports.Session()
+    mid = sess.host(d)
+
+    # the wire carries brightness as the string "80" (what a number input's .value is)
+    edit = {"rev": 0, "ops": [{"Set": {"path": [{"Key": "brightness"}], "value": {"Str": "80"}}}]}
+    auth = sess.submit(mid, edit)
+
+    assert auth is not None
+    assert d.brightness == 80  # the model coerced it to an int
+    assert sess.value(mid)["Map"]["brightness"] == {"Int": 80}  # the stored value is the canonical int, not "80"
+    # the authoritative patch broadcast to every client carries the canonical int as well
+    assert auth["ops"] == [{"Set": {"path": [{"Key": "brightness"}], "value": {"Int": 80}}}]

--- a/transports/tests/test_hub.py
+++ b/transports/tests/test_hub.py
@@ -51,6 +51,24 @@ def test_private_edit_relays_only_within_tenant():
     assert ca2.value(1)["Map"]["x"] == {"Int": 7}
 
 
+def test_private_invalid_edit_reverts_only_the_proposer():
+    """An invalid edit to a private model is rejected; the hub re-sends the authoritative snapshot to the
+    proposing connection alone (so its UI reverts) and relays nothing to the tenant's other connections."""
+    h = hub()
+    h.tenant("t1").host(Doc(x=5))
+    a1, a2 = ("t1", "a1"), ("t1", "a2")
+    h.open(a1)
+    h.open(a2)
+
+    bad = '{"t":"patch","id":1,"patch":{"rev":1,"ops":[{"Set":{"path":[{"Key":"x"}],"value":{"Str":""}}}]}}'
+    out = h.recv(a1, bad)
+    assert set(out) == {a1}  # only the proposer is messaged — no relay of the bad edit to a2
+    c = Client()
+    for m in out[a1]:
+        c.recv(m)
+    assert c.value(1)["Map"]["x"] == {"Int": 5}  # reverted to the authoritative value
+
+
 def test_shared_read_fanout_to_many_tenants():
     h = hub()
     sid = h.share(Doc())


### PR DESCRIPTION
Follow-up to #143. When a proposal is a **coercible** value — a number control sends its value as the string `"80"` — the core store kept the raw `"80"` while the refreshed Python model held the int `80`. A latent divergence between the core value, the model, and what other clients received.

## Fix
`Session.submit` now **validates *and* canonicalizes** the proposal through the hosted model (`_canonical`, replacing the validate-only `_validates`):
1. apply the proposal on a copy (the pure `apply`),
2. round-trip through the model bridge — pydantic / msgspec **validate** (reject bad input) and **coerce** (`"80"` → `80`),
3. make the authoritative patch the **diff to that canonical value**, not the client's raw ops.

So the core value, the Python model, and every client agree on the typed value (`int 80`), and an invalid value is still rejected (`None` → the caller reverts the proposer). For a well-typed edit the canonical diff equals the client's ops, so behavior is unchanged; only coercible/normalizable edits are corrected.

## Tests
- A coercible `"80"` lands as `int 80` in **both** the store and the broadcast patch.
- A hub test that an invalid private edit reverts only the proposer (covering #143's hub revert).
- **Full suite: 99 + new pass.**